### PR TITLE
Enhance regression notebook with R² metric and interpretability

### DIFF
--- a/src/Tox21_NR_PPAR_gamma_regression.ipynb
+++ b/src/Tox21_NR_PPAR_gamma_regression.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6a684ee",
+   "id": "f38f023f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0e85d0d",
+   "id": "eca7086c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,6 +30,7 @@
     "from matplotlib.colors import LinearSegmentedColormap\n",
     "\n",
     "from sklearn.model_selection import StratifiedKFold, train_test_split, KFold\n",
+    "import sklearn.metrics\n",
     "\n",
     "from tensorflow.keras import optimizers, layers, regularizers, metrics\n",
     "from tensorflow.keras.layers import (\n",
@@ -52,7 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff07ff70",
+   "id": "b46c8067",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8891638",
+   "id": "a5656bbf",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -82,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7721530a",
+   "id": "d4856fce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98fa7144",
+   "id": "a3d09043",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82978362",
+   "id": "1c4d51d0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc164a58",
+   "id": "41bb3ce8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "151158c2",
+   "id": "c61fc67f",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -609,7 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a265c74",
+   "id": "ddc6ee5d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,9 +618,16 @@
     "\n",
     "# Metrics for binary classification tasks\n",
     "# Metrics for regression tasks\n",
+    "def r2_score(y_true, y_pred):\n",
+    "    \"\"\"TensorFlow implementation of the coefficient of determination.\"\"\"\n",
+    "    ss_res = tf.reduce_sum(tf.square(y_true - y_pred))\n",
+    "    ss_tot = tf.reduce_sum(tf.square(y_true - tf.reduce_mean(y_true)))\n",
+    "    return 1 - ss_res / (ss_tot + tf.keras.backend.epsilon())\n",
+    "\n",
     "METRICS_REGRESSION = [\n",
     "    metrics.MeanAbsoluteError(name='mae'),\n",
     "    metrics.MeanSquaredError(name='mse'),\n",
+    "    r2_score,\n",
     "]\n",
     "\n",
     "\n",
@@ -629,7 +637,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d1ec02b",
+   "id": "5a6da772",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,8 +708,8 @@
     "# === Function to Format Results ===\n",
     "def format_results(phase1_result, phase3_train_result, phase3_test_result):\n",
     "    # Define Metric Names\n",
-    "    phase1_metrics = ['loss', 'mae', 'mse']\n",
-    "    phase3_metrics = ['loss', 'mae', 'mse']\n",
+    "    phase1_metrics = ['loss', 'mae', 'mse', 'r2_score']\n",
+    "    phase3_metrics = ['loss', 'mae', 'mse', 'r2_score']\n",
     "\n",
     "    # Create DataFrames\n",
     "    phase1_test_df = pd.DataFrame([phase1_result], columns=phase1_metrics)\n",
@@ -727,12 +735,68 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99e95292",
+   "id": "e971a78b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# === Scatter Plot of Predictions vs True Values ===\n",
+    "y_pred_test = model_phaz3.predict(X_test).flatten()\n",
+    "r2_val = sklearn.metrics.r2_score(y_test.flatten(), y_pred_test)\n",
+    "print(f\"Test R2 Score: {r2_val:.4f}\")\n",
+    "\n",
+    "plt.figure(figsize=(6, 6))\n",
+    "sns.scatterplot(x=y_test.flatten(), y=y_pred_test)\n",
+    "min_val = min(y_test.min(), y_pred_test.min())\n",
+    "max_val = max(y_test.max(), y_pred_test.max())\n",
+    "plt.plot([min_val, max_val], [min_val, max_val], 'r--')\n",
+    "plt.xlabel('True Values')\n",
+    "plt.ylabel('Predicted Values')\n",
+    "plt.title('True vs Predicted')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f32b7d8e",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
+    "\n",
+    "# === Attention Rollout Interpretability ===\n",
+    "def compute_attention_rollout(model, samples):\n",
+    "    inputs = tf.convert_to_tensor(samples)\n",
+    "    with tf.GradientTape() as tape:\n",
+    "        tape.watch(inputs)\n",
+    "        preds = model(inputs, training=False)\n",
+    "    grads = tape.gradient(preds, inputs)\n",
+    "    rollout = tf.reduce_mean(tf.abs(grads), axis=-1)\n",
+    "    return rollout.numpy()\n",
+    "\n",
+    "samples_train = X_train[:4]\n",
+    "rollouts_train = compute_attention_rollout(model_phaz3, samples_train)\n",
+    "for i in range(4):\n",
+    "    plt.figure()\n",
+    "    plt.plot(rollouts_train[i])\n",
+    "    plt.title(f'Train sample {i+1} attention rollout')\n",
+    "    plt.xlabel('Token index')\n",
+    "    plt.ylabel('Importance')\n",
+    "    plt.show()\n",
+    "\n",
+    "samples_test = X_test[:4]\n",
+    "rollouts_test = compute_attention_rollout(model_phaz3, samples_test)\n",
+    "for i in range(4):\n",
+    "    plt.figure()\n",
+    "    plt.plot(rollouts_test[i])\n",
+    "    plt.title(f'Test sample {i+1} attention rollout')\n",
+    "    plt.xlabel('Token index')\n",
+    "    plt.ylabel('Importance')\n",
+    "    plt.show()\n",
+    "\n",
+    "\n",
     "\n",
     "\n"
    ]


### PR DESCRIPTION
## Summary
- add `r2_score` function and include it in regression metrics
- report R² in results tables
- plot true vs. predicted values with a 1:1 reference line
- compute gradient-based attention rollout on four train and test examples

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6850c0a9c7608333b08319e78b94e806