### PR TITLE
Add metrics visualization for scaffold split classification

### DIFF
--- a/src/Tox21_NR_PPAR_gamma_Scaffold splitting.ipynb
+++ b/src/Tox21_NR_PPAR_gamma_Scaffold splitting.ipynb
@@ -1,1654 +1,1703 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "w71ntxmiP5Cs"
-      },
-      "source": [
-        "#Importing libraries"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "N2mc3-OTP210",
-        "outputId": "1bcf264f-343b-4610-b609-3c89f2b742f1"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "WARNING:tensorflow:From c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\tensorflow\\python\\util\\deprecation.py:588: calling function (from tensorflow.python.eager.polymorphic_function.polymorphic_function) with experimental_relax_shapes is deprecated and will be removed in a future version.\n",
-            "Instructions for updating:\n",
-            "experimental_relax_shapes is deprecated, use reduce_retracing instead\n"
-          ]
-        }
-      ],
-      "source": [
-        "import os\n",
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import tensorflow as tf\n",
-        "import keras\n",
-        "import seaborn as sns\n",
-        "import matplotlib.pyplot as plt\n",
-        "from matplotlib.colors import LinearSegmentedColormap\n",
-        "\n",
-        "from sklearn.model_selection import StratifiedKFold, train_test_split, KFold\n",
-        "from sklearn.utils.class_weight import compute_class_weight\n",
-        "from sklearn.metrics import classification_report, confusion_matrix\n",
-        "\n",
-        "from tensorflow.keras import optimizers, layers, regularizers, metrics\n",
-        "from tensorflow.keras.layers import (\n",
-        "    Lambda, Input, Reshape, Activation, Concatenate, Dense, Dropout,\n",
-        "    BatchNormalization, Conv1D, GlobalMaxPooling1D, LayerNormalization, GlobalAveragePooling1D\n",
-        ")\n",
-        "from tensorflow.keras.models import Model\n",
-        "from tensorflow.keras.utils import to_categorical\n",
-        "from tensorflow.keras.callbacks import LearningRateScheduler, EarlyStopping\n",
-        "\n",
-        "from einops import rearrange, repeat\n",
-        "from einops.layers.tensorflow import Rearrange\n",
-        "from deepchem.data import NumpyDataset\n",
-        "from deepchem.splits import ScaffoldSplitter\n",
-        "from keras.layers import Conv1D, GlobalMaxPooling1D, MaxPooling1D"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AFGjtuURP7OE"
-      },
-      "source": [
-        "### Cloning a GitHub repository"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "S-xDZ16oP-4J",
-        "outputId": "ed8899b2-2a9e-4f4c-d520-e07eced6dba1"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "fatal: destination path 'Deep-CBN' already exists and is not an empty directory.\n"
-          ]
-        }
-      ],
-      "source": [
-        "#!git clone https://github.com/akianfar/Deep-CBN.git"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DWrFzNjSQCtg"
-      },
-      "source": [
-        "### Loading and Preparing Data"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 241
-        },
-        "id": "kXFLqk2vja5M",
-        "outputId": "3e31a23d-130b-48c7-cfd4-bc76cd6c75bb"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>NR-AR</th>\n",
-              "      <th>NR-AR-LBD</th>\n",
-              "      <th>NR-AhR</th>\n",
-              "      <th>NR-Aromatase</th>\n",
-              "      <th>NR-ER</th>\n",
-              "      <th>NR-ER-LBD</th>\n",
-              "      <th>NR-PPAR-gamma</th>\n",
-              "      <th>SR-ARE</th>\n",
-              "      <th>SR-ATAD5</th>\n",
-              "      <th>SR-HSE</th>\n",
-              "      <th>SR-MMP</th>\n",
-              "      <th>SR-p53</th>\n",
-              "      <th>mol_id</th>\n",
-              "      <th>smiles</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>1.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>TOX3021</td>\n",
-              "      <td>CCOc1ccc2nc(S(N)(=O)=O)sc2c1</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>TOX3020</td>\n",
-              "      <td>CCN1C(=O)NC(c2ccccc2)C1=O</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>TOX3024</td>\n",
-              "      <td>CC[C@]1(O)CC[C@H]2[C@@H]3CCC4=CCCC[C@@H]4[C@H]...</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>NaN</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>TOX3027</td>\n",
-              "      <td>CCCN(CC)C(CC)C(=O)Nc1c(C)cccc1C</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>0.0</td>\n",
-              "      <td>TOX20800</td>\n",
-              "      <td>CC(O)(P(=O)(O)O)P(=O)(O)O</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "   NR-AR  NR-AR-LBD  NR-AhR  NR-Aromatase  NR-ER  NR-ER-LBD  NR-PPAR-gamma  \\\n",
-              "0    0.0        0.0     1.0           NaN    NaN        0.0            0.0   \n",
-              "1    0.0        0.0     0.0           0.0    0.0        0.0            0.0   \n",
-              "2    NaN        NaN     NaN           NaN    NaN        NaN            NaN   \n",
-              "3    0.0        0.0     0.0           0.0    0.0        0.0            0.0   \n",
-              "4    0.0        0.0     0.0           0.0    0.0        0.0            0.0   \n",
-              "\n",
-              "   SR-ARE  SR-ATAD5  SR-HSE  SR-MMP  SR-p53    mol_id  \\\n",
-              "0     1.0       0.0     0.0     0.0     0.0   TOX3021   \n",
-              "1     NaN       0.0     NaN     0.0     0.0   TOX3020   \n",
-              "2     0.0       NaN     0.0     NaN     NaN   TOX3024   \n",
-              "3     NaN       0.0     NaN     0.0     0.0   TOX3027   \n",
-              "4     0.0       0.0     0.0     0.0     0.0  TOX20800   \n",
-              "\n",
-              "                                              smiles  \n",
-              "0                       CCOc1ccc2nc(S(N)(=O)=O)sc2c1  \n",
-              "1                          CCN1C(=O)NC(c2ccccc2)C1=O  \n",
-              "2  CC[C@]1(O)CC[C@H]2[C@@H]3CCC4=CCCC[C@@H]4[C@H]...  \n",
-              "3                    CCCN(CC)C(CC)C(=O)Nc1c(C)cccc1C  \n",
-              "4                          CC(O)(P(=O)(O)O)P(=O)(O)O  "
-            ]
-          },
-          "execution_count": 7,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "data = pd.read_csv('../Data/tox21.csv')\n",
-        "data.head()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "id": "AFxos0tgQC9s"
-      },
-      "outputs": [],
-      "source": [
-        "smiles = data['smiles']\n",
-        "labels = data['NR-PPAR-gamma']\n",
-        "\n",
-        "# Dictionary to convert SMILES characters into numeric values\n",
-        "smiles_dict = {\n",
-        "    \"#\": 29, \"%\": 30, \")\": 31, \"(\": 1, \"+\": 32, \"-\": 33, \"/\": 34, \".\": 2,\n",
-        "    \"1\": 35, \"0\": 3, \"3\": 36, \"2\": 4, \"5\": 37, \"4\": 5, \"7\": 38, \"6\": 6,\n",
-        "    \"9\": 39, \"8\": 7, \"=\": 40, \"A\": 41, \"@\": 8, \"C\": 42, \"B\": 9, \"E\": 43,\n",
-        "    \"D\": 10, \"G\": 44, \"F\": 11, \"I\": 45, \"H\": 12, \"K\": 46, \"M\": 47, \"L\": 13,\n",
-        "    \"O\": 48, \"N\": 14, \"P\": 15, \"S\": 49, \"R\": 16, \"U\": 50, \"T\": 17, \"W\": 51,\n",
-        "    \"V\": 18, \"Y\": 52, \"[\": 53, \"Z\": 19, \"]\": 54, \"\\\\\": 20, \"a\": 55, \"c\": 56,\n",
-        "    \"b\": 21, \"e\": 57, \"d\": 22, \"g\": 58, \"f\": 23, \"i\": 59, \"h\": 24, \"m\": 60,\n",
-        "    \"l\": 25, \"o\": 61, \"n\": 26, \"s\": 62, \"r\": 27, \"u\": 63, \"t\": 28, \"y\": 64,\n",
-        "    \" \": 65, \":\": 66, \",\": 67, \"p\": 68, \"j\": 69, \"*\": 70\n",
-        "}\n",
-        "\n",
-        "def label_smiles(line, MAX_SMI_LEN, smi_ch_ind):\n",
-        "    X = np.zeros(MAX_SMI_LEN, dtype=int)\n",
-        "    for i, ch in enumerate(line[:MAX_SMI_LEN]):\n",
-        "        if ch in smi_ch_ind:\n",
-        "            X[i] = smi_ch_ind[ch]\n",
-        "    return X\n",
-        "\n",
-        "MAX_SMI_LEN = 100  # You can adjust this based on your needs\n",
-        "XD = np.array([label_smiles(str(smi), MAX_SMI_LEN, smiles_dict) for smi in smiles])\n",
-        "labels = labels.values\n",
-        "\n",
-        "# Convert to categorical\n",
-        "XD = to_categorical(XD, num_classes=71)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Qmjyj91JeXsG"
-      },
-      "source": [
-        "# phaze1"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "A2VgoLaMQN0X",
-        "outputId": "d183f5ed-45d0-496a-8aa7-9347ac07ec00"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"model_feature\"</span>\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1mModel: \"model_feature\"\u001b[0m\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓\n",
-              "┃<span style=\"font-weight: bold\"> Layer (type)                    </span>┃<span style=\"font-weight: bold\"> Output Shape           </span>┃<span style=\"font-weight: bold\">       Param # </span>┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩\n",
-              "│ XDinput (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)            │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">100</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">71</span>)        │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ conv1d (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Conv1D</span>)                 │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">99</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)         │         <span style=\"color: #00af00; text-decoration-color: #00af00\">9,152</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ conv1d_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Conv1D</span>)               │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">96</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)         │        <span style=\"color: #00af00; text-decoration-color: #00af00\">16,448</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ conv1d_2 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Conv1D</span>)               │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)        │        <span style=\"color: #00af00; text-decoration-color: #00af00\">32,896</span> │\n",
-              "└─────────────────────────────────┴────────────────────────┴───────────────┘\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓\n",
-              "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)                   \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape          \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      Param #\u001b[0m\u001b[1m \u001b[0m┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩\n",
-              "│ XDinput (\u001b[38;5;33mInputLayer\u001b[0m)            │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m100\u001b[0m, \u001b[38;5;34m71\u001b[0m)        │             \u001b[38;5;34m0\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ conv1d (\u001b[38;5;33mConv1D\u001b[0m)                 │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m99\u001b[0m, \u001b[38;5;34m64\u001b[0m)         │         \u001b[38;5;34m9,152\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ conv1d_1 (\u001b[38;5;33mConv1D\u001b[0m)               │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m96\u001b[0m, \u001b[38;5;34m64\u001b[0m)         │        \u001b[38;5;34m16,448\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ conv1d_2 (\u001b[38;5;33mConv1D\u001b[0m)               │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)        │        \u001b[38;5;34m32,896\u001b[0m │\n",
-              "└─────────────────────────────────┴────────────────────────┴───────────────┘\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">58,496</span> (228.50 KB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m58,496\u001b[0m (228.50 KB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">58,496</span> (228.50 KB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m58,496\u001b[0m (228.50 KB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (0.00 B)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m0\u001b[0m (0.00 B)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"functional\"</span>\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1mModel: \"functional\"\u001b[0m\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓\n",
-              "┃<span style=\"font-weight: bold\"> Layer (type)                    </span>┃<span style=\"font-weight: bold\"> Output Shape           </span>┃<span style=\"font-weight: bold\">       Param # </span>┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩\n",
-              "│ input_layer (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)        │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dense (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                   │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)        │        <span style=\"color: #00af00; text-decoration-color: #00af00\">66,048</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ batch_normalization             │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)        │         <span style=\"color: #00af00; text-decoration-color: #00af00\">2,048</span> │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">BatchNormalization</span>)            │                        │               │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dropout (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)               │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)        │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dense_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                 │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)        │       <span style=\"color: #00af00; text-decoration-color: #00af00\">131,328</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ batch_normalization_1           │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)        │         <span style=\"color: #00af00; text-decoration-color: #00af00\">1,024</span> │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">BatchNormalization</span>)            │                        │               │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dropout_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)             │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)        │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dense_2 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                 │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)         │        <span style=\"color: #00af00; text-decoration-color: #00af00\">16,448</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dense_3 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                 │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)          │           <span style=\"color: #00af00; text-decoration-color: #00af00\">130</span> │\n",
-              "└─────────────────────────────────┴────────────────────────┴───────────────┘\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓\n",
-              "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)                   \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape          \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      Param #\u001b[0m\u001b[1m \u001b[0m┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩\n",
-              "│ input_layer (\u001b[38;5;33mInputLayer\u001b[0m)        │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)        │             \u001b[38;5;34m0\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dense (\u001b[38;5;33mDense\u001b[0m)                   │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m512\u001b[0m)        │        \u001b[38;5;34m66,048\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ batch_normalization             │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m512\u001b[0m)        │         \u001b[38;5;34m2,048\u001b[0m │\n",
-              "│ (\u001b[38;5;33mBatchNormalization\u001b[0m)            │                        │               │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dropout (\u001b[38;5;33mDropout\u001b[0m)               │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m512\u001b[0m)        │             \u001b[38;5;34m0\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dense_1 (\u001b[38;5;33mDense\u001b[0m)                 │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m256\u001b[0m)        │       \u001b[38;5;34m131,328\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ batch_normalization_1           │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m256\u001b[0m)        │         \u001b[38;5;34m1,024\u001b[0m │\n",
-              "│ (\u001b[38;5;33mBatchNormalization\u001b[0m)            │                        │               │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dropout_1 (\u001b[38;5;33mDropout\u001b[0m)             │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m256\u001b[0m)        │             \u001b[38;5;34m0\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dense_2 (\u001b[38;5;33mDense\u001b[0m)                 │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m64\u001b[0m)         │        \u001b[38;5;34m16,448\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ dense_3 (\u001b[38;5;33mDense\u001b[0m)                 │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m2\u001b[0m)          │           \u001b[38;5;34m130\u001b[0m │\n",
-              "└─────────────────────────────────┴────────────────────────┴───────────────┘\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">217,026</span> (847.76 KB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m217,026\u001b[0m (847.76 KB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">215,490</span> (841.76 KB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m215,490\u001b[0m (841.76 KB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">1,536</span> (6.00 KB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m1,536\u001b[0m (6.00 KB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"interactionModel\"</span>\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1mModel: \"interactionModel\"\u001b[0m\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓\n",
-              "┃<span style=\"font-weight: bold\"> Layer (type)                    </span>┃<span style=\"font-weight: bold\"> Output Shape           </span>┃<span style=\"font-weight: bold\">       Param # </span>┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩\n",
-              "│ XDinput (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)            │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">100</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">71</span>)        │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ model_feature (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Functional</span>)      │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)        │        <span style=\"color: #00af00; text-decoration-color: #00af00\">58,496</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ functional (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Functional</span>)         │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)          │       <span style=\"color: #00af00; text-decoration-color: #00af00\">217,026</span> │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ global_average_pooling1d        │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)              │             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">GlobalAveragePooling1D</span>)        │                        │               │\n",
-              "└─────────────────────────────────┴────────────────────────┴───────────────┘\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓\n",
-              "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)                   \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape          \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m      Param #\u001b[0m\u001b[1m \u001b[0m┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩\n",
-              "│ XDinput (\u001b[38;5;33mInputLayer\u001b[0m)            │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m100\u001b[0m, \u001b[38;5;34m71\u001b[0m)        │             \u001b[38;5;34m0\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ model_feature (\u001b[38;5;33mFunctional\u001b[0m)      │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)        │        \u001b[38;5;34m58,496\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ functional (\u001b[38;5;33mFunctional\u001b[0m)         │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m2\u001b[0m)          │       \u001b[38;5;34m217,026\u001b[0m │\n",
-              "├─────────────────────────────────┼────────────────────────┼───────────────┤\n",
-              "│ global_average_pooling1d        │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2\u001b[0m)              │             \u001b[38;5;34m0\u001b[0m │\n",
-              "│ (\u001b[38;5;33mGlobalAveragePooling1D\u001b[0m)        │                        │               │\n",
-              "└─────────────────────────────────┴────────────────────────┴───────────────┘\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">275,522</span> (1.05 MB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m275,522\u001b[0m (1.05 MB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">273,986</span> (1.05 MB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m273,986\u001b[0m (1.05 MB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">1,536</span> (6.00 KB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m1,536\u001b[0m (6.00 KB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Feature model definition \n",
-        "XDinput = Input(shape=(100, 71), name='XDinput')\n",
-        "encode_smiles = Conv1D(filters=64, kernel_size=2, activation='relu', padding='valid', strides=1)(XDinput)  # (99,64)\n",
-        "encode_smiles = Conv1D(filters=64, kernel_size=4, activation='relu', padding='valid', strides=1)(encode_smiles)  # (96,64)\n",
-        "encode_smiles = Conv1D(filters=128, kernel_size=4, activation='relu', padding='valid', strides=1)(encode_smiles)  # (93,128)\n",
-        "model_feature = Model(inputs=XDinput, outputs=encode_smiles, name='model_feature')\n",
-        "model_feature.summary()\n",
-        "\n",
-        "# Prediction model definition\n",
-        "input_extracted_feature = Input(shape=(93, 128))\n",
-        "FC1 = Dense(512, activation='relu')(input_extracted_feature)\n",
-        "FC1 = BatchNormalization()(FC1)\n",
-        "FC2 = Dropout(0.1)(FC1)\n",
-        "FC3 = Dense(256, activation='relu')(FC2)\n",
-        "FC3 = BatchNormalization()(FC3)\n",
-        "FC4 = Dropout(0.1)(FC3)\n",
-        "FC5 = Dense(64, activation='relu')(FC4)\n",
-        "predictions = Dense(2, activation='softmax')(FC5)\n",
-        "model_pred = Model(inputs=input_extracted_feature, outputs=predictions)\n",
-        "model_pred.summary()\n",
-        "\n",
-        "# Full model definition with added Pooling layer\n",
-        "interaction_input = XDinput\n",
-        "encoded_features = model_feature(interaction_input)  # Output: (None, 93, 128)\n",
-        "predicted_output = model_pred(encoded_features)      # Output: (None, 93, 2)\n",
-        "\n",
-        "# Adding Pooling layer to reduce dimensionality\n",
-        "pooled_output = GlobalAveragePooling1D()(predicted_output)  # Output: (None, 2)\n",
-        "\n",
-        "# Final model definition\n",
-        "interactionModel = Model(inputs=interaction_input, outputs=pooled_output, name='interactionModel')\n",
-        "interactionModel.summary()\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KW4Dc7MfQWbn"
-      },
-      "source": [
-        "### BiFormer Block\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "id": "C5EAZalFQWpH"
-      },
-      "outputs": [],
-      "source": [
-        "# Define custom layers for 1D processing\n",
-        "class TopkRouting(layers.Layer):\n",
-        "    def __init__(self, qk_dim, topk=16, qk_scale=None, param_routing=False, diff_routing=False):\n",
-        "        super().__init__()\n",
-        "        self.topk = topk\n",
-        "        self.qk_dim = qk_dim\n",
-        "        self.scale = qk_scale if qk_scale is not None else qk_dim**-0.5\n",
-        "        self.diff_routing = diff_routing\n",
-        "        if param_routing:\n",
-        "            self.emb = layers.Dense(qk_dim)\n",
-        "        else:\n",
-        "            self.emb = lambda x: x\n",
-        "        self.routing_act = lambda x, axis: tf.nn.softmax(x, axis=axis)\n",
-        "\n",
-        "    def call(self, query, key, training=None):\n",
-        "        if not self.diff_routing:\n",
-        "            query = tf.stop_gradient(query)\n",
-        "            key = tf.stop_gradient(key)\n",
-        "        query_hat = self.emb(query)\n",
-        "        key_hat = self.emb(key)\n",
-        "\n",
-        "        attn_logit = tf.einsum('bnc,bqc->bnq', query_hat*self.scale, key_hat)  # Adjusted for 1D\n",
-        "        topk_attn_logit, topk_index = tf.math.top_k(attn_logit, k=self.topk, sorted=True)\n",
-        "        r_weight = self.routing_act(topk_attn_logit, axis=-1)\n",
-        "        return r_weight, topk_index\n",
-        "\n",
-        "def tf_gather_kv(kv, r_idx):\n",
-        "    n = tf.shape(kv)[0]\n",
-        "    p2 = tf.shape(kv)[1]\n",
-        "    c_kv = tf.shape(kv)[2]\n",
-        "    topk = tf.shape(r_idx)[2]\n",
-        "\n",
-        "    batch_idx = tf.reshape(tf.range(n), [n, 1, 1])\n",
-        "    batch_idx = tf.tile(batch_idx, [1, p2, topk])\n",
-        "    p2_idx = tf.reshape(tf.range(p2), [1, p2, 1])\n",
-        "    p2_idx = tf.tile(p2_idx, [n, 1, topk])\n",
-        "\n",
-        "    gather_indices = tf.stack([batch_idx, p2_idx, r_idx], axis=-1)\n",
-        "    gathered = tf.gather_nd(kv, gather_indices)\n",
-        "    return gathered  # Shape: (n, p2, topk, c_kv)\n",
-        "\n",
-        "class KVGather(layers.Layer):\n",
-        "    def __init__(self, mul_weight='none'):\n",
-        "        super().__init__()\n",
-        "        assert mul_weight in ['none', 'soft', 'hard']\n",
-        "        self.mul_weight = mul_weight\n",
-        "\n",
-        "    def call(self, r_idx, r_weight, kv, training=None):\n",
-        "        topk_kv = tf_gather_kv(kv, r_idx)\n",
-        "        if self.mul_weight == 'soft':\n",
-        "            r_weight_exp = tf.expand_dims(tf.expand_dims(r_weight, -1), -1)\n",
-        "            topk_kv = topk_kv * r_weight_exp\n",
-        "        return topk_kv\n",
-        "\n",
-        "class QKVLinear(layers.Layer):\n",
-        "    def __init__(self, dim, qk_dim, bias=True):\n",
-        "        super().__init__()\n",
-        "        self.dim = dim\n",
-        "        self.qk_dim = qk_dim\n",
-        "        self.qkv = layers.Dense(qk_dim + qk_dim + dim, use_bias=bias)\n",
-        "\n",
-        "    def call(self, x, training=None):\n",
-        "        qkv = self.qkv(x)\n",
-        "        q, kv = tf.split(qkv, [self.qk_dim, self.qk_dim + self.dim], axis=-1)\n",
-        "        return q, kv\n",
-        "\n",
-        "class BiLevelRoutingAttention(layers.Layer):\n",
-        "    def __init__(self, dim, n_win=7, num_heads=8, qk_dim=None, qk_scale=None,\n",
-        "                 kv_per_win=4, kv_downsample_ratio=4, kv_downsample_mode='identity',\n",
-        "                 topk=4, param_attention=\"qkvo\", param_routing=False, diff_routing=False, soft_routing=False,\n",
-        "                 side_dwconv=3, auto_pad=True):\n",
-        "        super().__init__()\n",
-        "        self.dim = dim\n",
-        "        self.n_win = n_win\n",
-        "        self.num_heads = num_heads\n",
-        "        self.qk_dim = qk_dim if qk_dim is not None else dim\n",
-        "        self.scale = qk_scale if qk_scale is not None else self.qk_dim**-0.5\n",
-        "        self.topk = topk\n",
-        "        self.param_routing = param_routing\n",
-        "        self.diff_routing = diff_routing\n",
-        "        self.soft_routing = soft_routing\n",
-        "        self.auto_pad = auto_pad\n",
-        "\n",
-        "        # For 1D, we use Conv1D\n",
-        "        if side_dwconv > 0:\n",
-        "            self.lepe = layers.Conv1D(dim, kernel_size=side_dwconv, padding='same', activation='relu')\n",
-        "        else:\n",
-        "            self.lepe = lambda x: tf.zeros_like(x)\n",
-        "\n",
-        "        self.router = TopkRouting(qk_dim=self.qk_dim, topk=self.topk, qk_scale=self.scale,\n",
-        "                                  param_routing=self.param_routing, diff_routing=self.diff_routing)\n",
-        "\n",
-        "        mul_weight = 'none'\n",
-        "        if self.soft_routing:\n",
-        "            mul_weight = 'soft'\n",
-        "        self.kv_gather = KVGather(mul_weight=mul_weight)\n",
-        "\n",
-        "        if param_attention in ['qkvo', 'qkv']:\n",
-        "            self.qkv = QKVLinear(self.dim, self.qk_dim)\n",
-        "            if param_attention == 'qkvo':\n",
-        "                self.wo = layers.Dense(self.dim)\n",
-        "            else:\n",
-        "                self.wo = lambda x: x\n",
-        "        else:\n",
-        "            raise ValueError(\"Unsupported param_attention mode\")\n",
-        "\n",
-        "        self.attn_act = lambda x: tf.nn.softmax(x, axis=-1)\n",
-        "        self.kv_down = lambda x: x  # identity for simplicity\n",
-        "\n",
-        "    def call(self, x, training=None, ret_attn_mask=False):\n",
-        "        # Implementing full attention can be complex, so here we only keep the general structure\n",
-        "        if ret_attn_mask:\n",
-        "            return x, None, None, None\n",
-        "        else:\n",
-        "            return x\n",
-        "\n",
-        "class Attention(layers.Layer):\n",
-        "    def __init__(self, dim, num_heads=8, qkv_bias=False, qk_scale=None, attn_drop=0., proj_drop=0.):\n",
-        "        super().__init__()\n",
-        "        self.num_heads = num_heads\n",
-        "        head_dim = dim // num_heads\n",
-        "        self.scale = qk_scale if qk_scale is not None else head_dim**-0.5\n",
-        "        self.qkv = layers.Dense(dim*3, use_bias=qkv_bias)\n",
-        "        self.attn_drop = layers.Dropout(attn_drop)\n",
-        "        self.proj = layers.Dense(dim)\n",
-        "        self.proj_drop = layers.Dropout(proj_drop)\n",
-        "\n",
-        "    def call(self, x, training=None):\n",
-        "        batch_size, seq_length, dim = tf.unstack(tf.shape(x))\n",
-        "        qkv = self.qkv(x)\n",
-        "        q, k, v = tf.split(qkv, 3, axis=-1)\n",
-        "        q = rearrange(q, 'b s (h d) -> b h s d', h=self.num_heads)\n",
-        "        k = rearrange(k, 'b s (h d) -> b h s d', h=self.num_heads)\n",
-        "        v = rearrange(v, 'b s (h d) -> b h s d', h=self.num_heads)\n",
-        "\n",
-        "        attn = tf.einsum('bhid,bhjd->bhij', q, k) * self.scale\n",
-        "        attn = tf.nn.softmax(attn, axis=-1)\n",
-        "        attn = self.attn_drop(attn, training=training)\n",
-        "        out = tf.einsum('bhij,bhjd->bhid', attn, v)\n",
-        "        out = rearrange(out, 'b h s d -> b s (h d)')\n",
-        "        out = self.proj(out)\n",
-        "        out = self.proj_drop(out, training=training)\n",
-        "        return out\n",
-        "\n",
-        "class AttentionLePE(layers.Layer):\n",
-        "    def __init__(self, dim, num_heads=8, qkv_bias=False, qk_scale=None, attn_drop=0., proj_drop=0., side_dwconv=5):\n",
-        "        super().__init__()\n",
-        "        self.num_heads = num_heads\n",
-        "        head_dim = dim // num_heads\n",
-        "        self.scale = qk_scale if qk_scale is not None else head_dim**-0.5\n",
-        "        self.qkv = layers.Dense(dim*3, use_bias=qkv_bias)\n",
-        "        self.attn_drop = layers.Dropout(attn_drop)\n",
-        "        self.proj = layers.Dense(dim)\n",
-        "        self.proj_drop = layers.Dropout(proj_drop)\n",
-        "        if side_dwconv > 0:\n",
-        "            self.lepe = layers.Conv1D(dim, kernel_size=side_dwconv, padding='same', activation='relu')\n",
-        "        else:\n",
-        "            self.lepe = lambda x: tf.zeros_like(x)\n",
-        "\n",
-        "    def call(self, x, training=None):\n",
-        "        lepe_out = self.lepe(x)\n",
-        "        qkv = self.qkv(x)\n",
-        "        q, k, v = tf.split(qkv, 3, axis=-1)\n",
-        "        q = rearrange(q, 'b s (h d) -> b h s d', h=self.num_heads)\n",
-        "        k = rearrange(k, 'b s (h d) -> b h s d', h=self.num_heads)\n",
-        "        v = rearrange(v, 'b s (h d) -> b h s d', h=self.num_heads)\n",
-        "\n",
-        "        attn = tf.einsum('bhid,bhjd->bhij', q, k) * self.scale\n",
-        "        attn = tf.nn.softmax(attn, axis=-1)\n",
-        "        attn = self.attn_drop(attn, training=training)\n",
-        "        out = tf.einsum('bhij,bhjd->bhid', attn, v)\n",
-        "        out = rearrange(out, 'b h s d -> b s (h d)')\n",
-        "        out = out + lepe_out\n",
-        "        out = self.proj(out)\n",
-        "        out = self.proj_drop(out, training=training)\n",
-        "        return out\n",
-        "\n",
-        "class PreNorm(layers.Layer):\n",
-        "    def __init__(self, fn):\n",
-        "        super(PreNorm, self).__init__()\n",
-        "        self.norm = layers.LayerNormalization()\n",
-        "        self.fn = fn\n",
-        "\n",
-        "    def call(self, x, training=True):\n",
-        "        return self.fn(self.norm(x), training=training)\n",
-        "\n",
-        "class MLP(layers.Layer):\n",
-        "    def __init__(self, dim, hidden_dim, dropout=0.2):\n",
-        "        super(MLP, self).__init__()\n",
-        "        self.net = keras.Sequential([\n",
-        "            layers.Dense(hidden_dim),\n",
-        "            layers.Activation('gelu'),\n",
-        "            layers.Dropout(rate=dropout),\n",
-        "            layers.Dense(dim),\n",
-        "            layers.Dropout(rate=dropout)\n",
-        "        ])\n",
-        "\n",
-        "    def call(self, x, training=True):\n",
-        "        return self.net(x, training=training)\n",
-        "\n",
-        "class DropPath(layers.Layer):\n",
-        "    # Placeholder for DropPath, currently no-op\n",
-        "    def __init__(self, drop_prob=0.):\n",
-        "        super().__init__()\n",
-        "        self.drop_prob = drop_prob\n",
-        "\n",
-        "    def call(self, x, training=None):\n",
-        "        if (not training) or self.drop_prob == 0.:\n",
-        "            return x\n",
-        "        keep_prob = 1 - self.drop_prob\n",
-        "        random_tensor = keep_prob\n",
-        "        random_tensor += tf.random.uniform(tf.shape(x), dtype=x.dtype)\n",
-        "        binary_tensor = tf.floor(random_tensor)\n",
-        "        return tf.divide(x, keep_prob) * binary_tensor\n",
-        "\n",
-        "class Block(layers.Layer):\n",
-        "    def __init__(self, dim, drop_path=0.1, layer_scale_init_value=-1,\n",
-        "                 num_heads=8, n_win=7, qk_dim=128, qk_scale=None,\n",
-        "                 kv_per_win=8, kv_downsample_ratio=1, kv_downsample_mode='identity',\n",
-        "                 topk=8, param_attention=\"qkvo\", param_routing=True, diff_routing=False, soft_routing=True,\n",
-        "                 mlp_ratio=4, mlp_dwconv=False, side_dwconv=5, before_attn_dwconv=3, pre_norm=True, auto_pad=True):\n",
-        "        super().__init__()\n",
-        "        qk_dim = qk_dim or dim\n",
-        "\n",
-        "        # For 1D, we use Conv1D\n",
-        "        if before_attn_dwconv > 0:\n",
-        "            self.pos_embed = layers.Conv1D(dim, kernel_size=before_attn_dwconv, padding='same', activation='relu')\n",
-        "        else:\n",
-        "            self.pos_embed = lambda x: tf.zeros_like(x)\n",
-        "\n",
-        "        self.norm1 = layers.LayerNormalization(epsilon=1e-6)\n",
-        "\n",
-        "        if topk > 0:\n",
-        "            self.attn = BiLevelRoutingAttention(dim=dim, num_heads=num_heads, n_win=n_win, qk_dim=qk_dim,\n",
-        "                                               qk_scale=qk_scale, kv_per_win=kv_per_win, kv_downsample_ratio=kv_downsample_ratio,\n",
-        "                                               kv_downsample_mode=kv_downsample_mode, topk=topk, param_attention=param_attention,\n",
-        "                                               param_routing=param_routing, diff_routing=diff_routing, soft_routing=soft_routing,\n",
-        "                                               side_dwconv=side_dwconv, auto_pad=auto_pad)\n",
-        "        elif topk == -1:\n",
-        "            self.attn = Attention(dim=dim, num_heads=num_heads, qk_scale=qk_scale)\n",
-        "        elif topk == -2:\n",
-        "            self.attn = AttentionLePE(dim=dim, num_heads=num_heads, qk_scale=qk_scale, side_dwconv=side_dwconv)\n",
-        "        elif topk == 0:\n",
-        "            # Pseudo attention\n",
-        "            self.attn = keras.Sequential([\n",
-        "                layers.Dense(dim),\n",
-        "                layers.Conv1D(dim, kernel_size=5, padding='same', activation='relu'),\n",
-        "                layers.Dense(dim)\n",
-        "            ])\n",
-        "\n",
-        "        self.norm2 = layers.LayerNormalization(epsilon=1e-6)\n",
-        "\n",
-        "        mlp_hidden_dim = int(mlp_ratio * dim)\n",
-        "        mlp_layers = [layers.Dense(mlp_hidden_dim)]\n",
-        "        if mlp_dwconv:\n",
-        "            mlp_layers.append(layers.Conv1D(mlp_hidden_dim, kernel_size=3, padding='same', activation='relu'))\n",
-        "        mlp_layers.append(layers.Activation('gelu'))\n",
-        "        mlp_layers.append(layers.Dense(dim))\n",
-        "        mlp_layers.insert(1, layers.Dropout(0.2)) # Add dropout after first Dense\n",
-        "        mlp_layers.append(layers.Dropout(0.2))\n",
-        "        self.mlp = keras.Sequential(mlp_layers)\n",
-        "\n",
-        "        self.drop_path = DropPath(drop_path) if drop_path > 0. else layers.Lambda(lambda x: x)\n",
-        "\n",
-        "        if layer_scale_init_value > 0:\n",
-        "            self.use_layer_scale = True\n",
-        "            self.gamma1 = self.add_weight(shape=(dim,),\n",
-        "                                          initializer=tf.keras.initializers.Constant(layer_scale_init_value),\n",
-        "                                          trainable=True)\n",
-        "            self.gamma2 = self.add_weight(shape=(dim,),\n",
-        "                                          initializer=tf.keras.initializers.Constant(layer_scale_init_value),\n",
-        "                                          trainable=True)\n",
-        "        else:\n",
-        "            self.use_layer_scale = False\n",
-        "\n",
-        "        self.pre_norm = pre_norm\n",
-        "\n",
-        "    def call(self, x, training=None):\n",
-        "        x = x + self.pos_embed(x)  # Add positional embedding\n",
-        "\n",
-        "        if self.pre_norm:\n",
-        "            if self.use_layer_scale:\n",
-        "                x = x + self.drop_path(self.gamma1 * self.attn(self.norm1(x), training=training), training=training)\n",
-        "                x = x + self.drop_path(self.gamma2 * self.mlp(self.norm2(x), training=training), training=training)\n",
-        "            else:\n",
-        "                x = x + self.drop_path(self.attn(self.norm1(x), training=training), training=training)\n",
-        "                x = x + self.drop_path(self.mlp(self.norm2(x), training=training), training=training)\n",
-        "        else:\n",
-        "            if self.use_layer_scale:\n",
-        "                tmp = x + self.drop_path(self.gamma1 * self.attn(x, training=training), training=training)\n",
-        "                x = self.norm1(tmp)\n",
-        "                tmp = x + self.drop_path(self.gamma2 * self.mlp(x, training=training), training=training)\n",
-        "                x = self.norm2(tmp)\n",
-        "            else:\n",
-        "                tmp = x + self.drop_path(self.attn(x, training=training), training=training)\n",
-        "                x = self.norm1(tmp)\n",
-        "                tmp = x + self.drop_path(self.mlp(x, training=training), training=training)\n",
-        "                x = self.norm2(tmp)\n",
-        "\n",
-        "        return x\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "k41fqbmrQxbV"
-      },
-      "source": [
-        "# phaze2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 599
-        },
-        "id": "qFxfd5e4QdV3",
-        "outputId": "3ffefc83-bb87-45ff-cb54-e4535be8d055"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "WARNING:tensorflow:From c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\backend\\tensorflow\\core.py:232: The name tf.placeholder is deprecated. Please use tf.compat.v1.placeholder instead.\n",
-            "\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\layers\\layer.py:421: UserWarning: `build()` was called on layer 'bi_level_routing_attention', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.\n",
-            "  warnings.warn(\n",
-            "c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\layers\\layer.py:421: UserWarning: `build()` was called on layer 'bi_level_routing_attention_1', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"functional_3\"</span>\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1mModel: \"functional_3\"\u001b[0m\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
-              "┃<span style=\"font-weight: bold\"> Layer (type)        </span>┃<span style=\"font-weight: bold\"> Output Shape      </span>┃<span style=\"font-weight: bold\">    Param # </span>┃<span style=\"font-weight: bold\"> Connected to      </span>┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
-              "│ input_layer_1       │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ -                 │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ block (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Block</span>)       │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   │    <span style=\"color: #00af00; text-decoration-color: #00af00\">148,608</span> │ input_layer_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ block_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Block</span>)     │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   │    <span style=\"color: #00af00; text-decoration-color: #00af00\">148,608</span> │ input_layer_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ lambda (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)     │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)     │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ block[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]       │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ lambda_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)   │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)     │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ block_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]     │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ concatenate         │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)     │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ lambda[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>],     │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Concatenate</span>)       │                   │            │ lambda_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ global_average_poo… │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)         │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ concatenate[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>] │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">GlobalAveragePool…</span> │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ difference (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>) │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)         │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ global_average_p… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ activation_11       │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)         │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ difference[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]  │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Activation</span>)        │                   │            │                   │\n",
-              "└─────────────────────┴───────────────────┴────────────┴───────────────────┘\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
-              "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape     \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m   Param #\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mConnected to     \u001b[0m\u001b[1m \u001b[0m┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
-              "│ input_layer_1       │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   │          \u001b[38;5;34m0\u001b[0m │ -                 │\n",
-              "│ (\u001b[38;5;33mInputLayer\u001b[0m)        │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ block (\u001b[38;5;33mBlock\u001b[0m)       │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   │    \u001b[38;5;34m148,608\u001b[0m │ input_layer_1[\u001b[38;5;34m0\u001b[0m]… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ block_1 (\u001b[38;5;33mBlock\u001b[0m)     │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   │    \u001b[38;5;34m148,608\u001b[0m │ input_layer_1[\u001b[38;5;34m0\u001b[0m]… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ lambda (\u001b[38;5;33mLambda\u001b[0m)     │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m1\u001b[0m)     │          \u001b[38;5;34m0\u001b[0m │ block[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]       │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ lambda_1 (\u001b[38;5;33mLambda\u001b[0m)   │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m1\u001b[0m)     │          \u001b[38;5;34m0\u001b[0m │ block_1[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]     │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ concatenate         │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m2\u001b[0m)     │          \u001b[38;5;34m0\u001b[0m │ lambda[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m],     │\n",
-              "│ (\u001b[38;5;33mConcatenate\u001b[0m)       │                   │            │ lambda_1[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ global_average_poo… │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2\u001b[0m)         │          \u001b[38;5;34m0\u001b[0m │ concatenate[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m] │\n",
-              "│ (\u001b[38;5;33mGlobalAveragePool…\u001b[0m │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ difference (\u001b[38;5;33mLambda\u001b[0m) │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m1\u001b[0m)         │          \u001b[38;5;34m0\u001b[0m │ global_average_p… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ activation_11       │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m1\u001b[0m)         │          \u001b[38;5;34m0\u001b[0m │ difference[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]  │\n",
-              "│ (\u001b[38;5;33mActivation\u001b[0m)        │                   │            │                   │\n",
-              "└─────────────────────┴───────────────────┴────────────┴───────────────────┘\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">297,216</span> (1.13 MB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m297,216\u001b[0m (1.13 MB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">297,216</span> (1.13 MB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m297,216\u001b[0m (1.13 MB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (0.00 B)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m0\u001b[0m (0.00 B)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Parameter settings for the block\n",
-        "dim = 128   \n",
-        "num_heads = 8\n",
-        "mlp_dim = 128 * 3  \n",
-        "depth = 2\n",
-        "dim_head = 48\n",
-        "\n",
-        "# Create Phase 2 model\n",
-        "input_phaz2 = Input(shape=(93, 128))  \n",
-        "\n",
-        "processed_input = input_phaz2\n",
-        "\n",
-        "# Define transformer blocks\n",
-        "transformer_block1 = Block(dim=dim, drop_path=0.2, num_heads=num_heads, topk=16, mlp_ratio=3)\n",
-        "transformer_block2 = Block(dim=dim, drop_path=0.2, num_heads=num_heads, topk=16, mlp_ratio=3)\n",
-        "\n",
-        "# Apply the first transformer block\n",
-        "transformer_output1 = transformer_block1(processed_input)\n",
-        "# Compute the norm of the output along the last axis (preserving dimensions)\n",
-        "transformer_output1 = Lambda(lambda x: tf.norm(x, axis=-1, keepdims=True))(transformer_output1)\n",
-        "\n",
-        "# Apply the second transformer block\n",
-        "transformer_output2 = transformer_block2(processed_input)\n",
-        "# Compute the norm of the output along the last axis (preserving dimensions)\n",
-        "transformer_output2 = Lambda(lambda x: tf.norm(x, axis=-1, keepdims=True))(transformer_output2)\n",
-        "\n",
-        "# Combine the outputs of both transformer blocks along the last axis\n",
-        "combined_outputs = Concatenate(axis=-1)([transformer_output1, transformer_output2])\n",
-        "\n",
-        "# Apply global average pooling to reduce the output to (batch_size, 2)\n",
-        "pooled_outputs = GlobalAveragePooling1D()(combined_outputs)\n",
-        "\n",
-        "# Compute the difference between the two pooled outputs and reshape to (batch_size, 1)\n",
-        "difference = Lambda(lambda x: tf.expand_dims(x[:, 0] - x[:, 1], axis=-1), name='difference')(pooled_outputs)\n",
-        "\n",
-        "# Apply sigmoid activation to normalize the output to the range [0, 1]\n",
-        "condition_2 = Activation('sigmoid', name='activation_11')(difference)\n",
-        "\n",
-        "# Freeze the `model_feature` layers to prevent them from being trained\n",
-        "model_feature.trainable = False\n",
-        "\n",
-        "# Define the complete model\n",
-        "model_phaz2 = Model(inputs=input_phaz2, outputs=condition_2)\n",
-        "model_phaz2.summary()\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HcH6Y5x1e5OS"
-      },
-      "source": [
-        "# phaze3"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "F6DTjT17Q1W5",
-        "outputId": "6bcfc3f8-eeee-418e-cddd-31ff826c0ff5"
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\layers\\layer.py:421: UserWarning: `build()` was called on layer 'bi_level_routing_attention_2', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.\n",
-            "  warnings.warn(\n",
-            "c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\layers\\layer.py:421: UserWarning: `build()` was called on layer 'bi_level_routing_attention_3', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "input_layer_4 True\n",
-            "model_feature False\n",
-            "block_2 False\n",
-            "block_3 False\n",
-            "lambda_2 True\n",
-            "lambda_3 True\n",
-            "concatenate_1 True\n",
-            "global_average_pooling1d_2 True\n",
-            "dense_24 True\n",
-            "batch_normalization_2 True\n",
-            "dropout_10 True\n",
-            "dense_25 True\n",
-            "batch_normalization_3 True\n",
-            "dropout_11 True\n",
-            "dense_26 True\n",
-            "dense_27 True\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"functional_6\"</span>\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1mModel: \"functional_6\"\u001b[0m\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
-              "┃<span style=\"font-weight: bold\"> Layer (type)        </span>┃<span style=\"font-weight: bold\"> Output Shape      </span>┃<span style=\"font-weight: bold\">    Param # </span>┃<span style=\"font-weight: bold\"> Connected to      </span>┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
-              "│ input_layer_4       │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">100</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">71</span>)   │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ -                 │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ model_feature       │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   │     <span style=\"color: #00af00; text-decoration-color: #00af00\">58,496</span> │ input_layer_4[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]… │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Functional</span>)        │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ block_2 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Block</span>)     │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   │    <span style=\"color: #00af00; text-decoration-color: #00af00\">148,608</span> │ model_feature[<span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>]… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ block_3 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Block</span>)     │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   │    <span style=\"color: #00af00; text-decoration-color: #00af00\">148,608</span> │ model_feature[<span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>]… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ lambda_2 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)   │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)     │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ block_2[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]     │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ lambda_3 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)   │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)     │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ block_3[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]     │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ concatenate_1       │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)     │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ lambda_2[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>],   │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Concatenate</span>)       │                   │            │ lambda_3[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ global_average_poo… │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)         │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ concatenate_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]… │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">GlobalAveragePool…</span> │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dense_24 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)    │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)       │      <span style=\"color: #00af00; text-decoration-color: #00af00\">1,536</span> │ global_average_p… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ batch_normalizatio… │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)       │      <span style=\"color: #00af00; text-decoration-color: #00af00\">2,048</span> │ dense_24[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">BatchNormalizatio…</span> │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dropout_10          │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)       │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ batch_normalizat… │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)           │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dense_25 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)    │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)       │    <span style=\"color: #00af00; text-decoration-color: #00af00\">131,328</span> │ dropout_10[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]  │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ batch_normalizatio… │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)       │      <span style=\"color: #00af00; text-decoration-color: #00af00\">1,024</span> │ dense_25[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">BatchNormalizatio…</span> │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dropout_11          │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)       │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ batch_normalizat… │\n",
-              "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)           │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dense_26 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)    │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)        │     <span style=\"color: #00af00; text-decoration-color: #00af00\">16,448</span> │ dropout_11[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]  │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dense_27 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)    │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)         │        <span style=\"color: #00af00; text-decoration-color: #00af00\">130</span> │ dense_26[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    │\n",
-              "└─────────────────────┴───────────────────┴────────────┴───────────────────┘\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
-              "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape     \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m   Param #\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mConnected to     \u001b[0m\u001b[1m \u001b[0m┃\n",
-              "┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
-              "│ input_layer_4       │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m100\u001b[0m, \u001b[38;5;34m71\u001b[0m)   │          \u001b[38;5;34m0\u001b[0m │ -                 │\n",
-              "│ (\u001b[38;5;33mInputLayer\u001b[0m)        │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ model_feature       │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   │     \u001b[38;5;34m58,496\u001b[0m │ input_layer_4[\u001b[38;5;34m0\u001b[0m]… │\n",
-              "│ (\u001b[38;5;33mFunctional\u001b[0m)        │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ block_2 (\u001b[38;5;33mBlock\u001b[0m)     │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   │    \u001b[38;5;34m148,608\u001b[0m │ model_feature[\u001b[38;5;34m1\u001b[0m]… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ block_3 (\u001b[38;5;33mBlock\u001b[0m)     │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   │    \u001b[38;5;34m148,608\u001b[0m │ model_feature[\u001b[38;5;34m1\u001b[0m]… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ lambda_2 (\u001b[38;5;33mLambda\u001b[0m)   │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m1\u001b[0m)     │          \u001b[38;5;34m0\u001b[0m │ block_2[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]     │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ lambda_3 (\u001b[38;5;33mLambda\u001b[0m)   │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m1\u001b[0m)     │          \u001b[38;5;34m0\u001b[0m │ block_3[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]     │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ concatenate_1       │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m2\u001b[0m)     │          \u001b[38;5;34m0\u001b[0m │ lambda_2[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m],   │\n",
-              "│ (\u001b[38;5;33mConcatenate\u001b[0m)       │                   │            │ lambda_3[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ global_average_poo… │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2\u001b[0m)         │          \u001b[38;5;34m0\u001b[0m │ concatenate_1[\u001b[38;5;34m0\u001b[0m]… │\n",
-              "│ (\u001b[38;5;33mGlobalAveragePool…\u001b[0m │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dense_24 (\u001b[38;5;33mDense\u001b[0m)    │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m512\u001b[0m)       │      \u001b[38;5;34m1,536\u001b[0m │ global_average_p… │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ batch_normalizatio… │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m512\u001b[0m)       │      \u001b[38;5;34m2,048\u001b[0m │ dense_24[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    │\n",
-              "│ (\u001b[38;5;33mBatchNormalizatio…\u001b[0m │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dropout_10          │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m512\u001b[0m)       │          \u001b[38;5;34m0\u001b[0m │ batch_normalizat… │\n",
-              "│ (\u001b[38;5;33mDropout\u001b[0m)           │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dense_25 (\u001b[38;5;33mDense\u001b[0m)    │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m256\u001b[0m)       │    \u001b[38;5;34m131,328\u001b[0m │ dropout_10[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]  │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ batch_normalizatio… │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m256\u001b[0m)       │      \u001b[38;5;34m1,024\u001b[0m │ dense_25[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    │\n",
-              "│ (\u001b[38;5;33mBatchNormalizatio…\u001b[0m │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dropout_11          │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m256\u001b[0m)       │          \u001b[38;5;34m0\u001b[0m │ batch_normalizat… │\n",
-              "│ (\u001b[38;5;33mDropout\u001b[0m)           │                   │            │                   │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dense_26 (\u001b[38;5;33mDense\u001b[0m)    │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m64\u001b[0m)        │     \u001b[38;5;34m16,448\u001b[0m │ dropout_11[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]  │\n",
-              "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-              "│ dense_27 (\u001b[38;5;33mDense\u001b[0m)    │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2\u001b[0m)         │        \u001b[38;5;34m130\u001b[0m │ dense_26[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    │\n",
-              "└─────────────────────┴───────────────────┴────────────┴───────────────────┘\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">508,226</span> (1.94 MB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m508,226\u001b[0m (1.94 MB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">150,978</span> (589.76 KB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m150,978\u001b[0m (589.76 KB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">357,248</span> (1.36 MB)\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m357,248\u001b[0m (1.36 MB)\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "# Define new transformer blocks\n",
-        "new_transformer_block = Block(dim=dim, drop_path=0.2, num_heads=num_heads, topk=16, mlp_ratio=3)\n",
-        "new_transformer_block2 = Block(dim=dim, drop_path=0.2, num_heads=num_heads, topk=16, mlp_ratio=3)\n",
-        "\n",
-        "# Input for Phase 3\n",
-        "XDinput_phaz3 = Input(shape=(100, 71))\n",
-        "# Pass input through the feature extraction model\n",
-        "model_feature_output = model_feature(XDinput_phaz3)  # Output shape: (93, 192)\n",
-        "\n",
-        "# Transformer blocks processing\n",
-        "transformer_output1_phaz3 = new_transformer_block(model_feature_output)  # Output shape: (93, 192)\n",
-        "# Compute the norm along the last axis, retaining dimensions\n",
-        "transformer_output1_phaz3 = layers.Lambda(lambda x: tf.norm(x, axis=-1, keepdims=True))(transformer_output1_phaz3)  # Shape: (93, 1)\n",
-        "\n",
-        "transformer_output2_phaz3 = new_transformer_block2(model_feature_output)  # Output shape: (93, 192)\n",
-        "# Compute the norm along the last axis, retaining dimensions\n",
-        "transformer_output2_phaz3 = layers.Lambda(lambda x: tf.norm(x, axis=-1, keepdims=True))(transformer_output2_phaz3)  # Shape: (93, 1)\n",
-        "\n",
-        "# Combine the outputs of both transformer blocks\n",
-        "concatenated_phaz3 = Concatenate(axis=-1)([transformer_output1_phaz3, transformer_output2_phaz3])  # Shape: (93, 2)\n",
-        "\n",
-        "# Freeze the weights of feature extractor and transformer blocks\n",
-        "model_feature.trainable = False\n",
-        "new_transformer_block.trainable = False\n",
-        "new_transformer_block2.trainable = False\n",
-        "\n",
-        "# Apply global average pooling to reduce the dimensions to (batch_size, 2)\n",
-        "pooled_phaz3 = GlobalAveragePooling1D()(concatenated_phaz3)  # Shape: (None, 2)\n",
-        "\n",
-        "# Fully connected layers\n",
-        "FC1_phaz3 = Dense(512, activation='relu')(pooled_phaz3)\n",
-        "FC1_phaz3 = BatchNormalization()(FC1_phaz3)\n",
-        "FC2_phaz3 = Dropout(0.1)(FC1_phaz3)  # Increased dropout rate\n",
-        "FC3_phaz3 = Dense(256, activation='relu')(FC2_phaz3)\n",
-        "FC3_phaz3 = BatchNormalization()(FC3_phaz3)\n",
-        "FC4_phaz3 = Dropout(0.1)(FC3_phaz3)  # Increased dropout rate\n",
-        "FC5_phaz3 = Dense(64, activation='relu')(FC4_phaz3)\n",
-        "\n",
-        "# Final prediction layer with softmax activation\n",
-        "predictions_phaz3 = Dense(2, activation='softmax')(FC5_phaz3)\n",
-        "\n",
-        "# Define the complete model for Phase 3\n",
-        "model_phaz3 = Model(inputs=XDinput_phaz3, outputs=predictions_phaz3)\n",
-        "\n",
-        "# Print the name and trainable status of each layer\n",
-        "for layer in model_phaz3.layers:\n",
-        "    print(layer.name, layer.trainable)\n",
-        "\n",
-        "# Model summary\n",
-        "model_phaz3.summary()\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "id": "jF60_7QXQ4lB"
-      },
-      "outputs": [],
-      "source": [
-        "# Metrics for binary classification tasks\n",
-        "METRICS_BINARY = [\n",
-        "    metrics.BinaryAccuracy(name='accuracy'),  # Calculates accuracy for binary classification\n",
-        "    metrics.AUC(name='auc'),  # Area Under the Curve (ROC AUC) metric\n",
-        "]\n",
-        "\n",
-        "# Metrics for categorical (multi-class) classification tasks\n",
-        "METRICS_CATEGORICAL = [\n",
-        "    metrics.CategoricalAccuracy(name='accuracy'),  # Calculates accuracy for multi-class classification\n",
-        "    metrics.Precision(name='precision'),  # Precision: TP / (TP + FP)\n",
-        "    metrics.Recall(name='recall'),  # Recall: TP / (TP + FN)\n",
-        "    metrics.AUC(name='auc'),  # Area Under the Curve (ROC AUC) metric\n",
-        "    metrics.F1Score(average='macro', name='f1_score')  # F1 Score (macro-averaged): Harmonic mean of precision and recall\n",
-        "]\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hBNS2iz6f9xP"
-      },
-      "source": [
-        "# Train and Validation"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "xcS3ex1TgCRK",
-        "outputId": "7a3df7f6-88ae-459e-8e9d-fde383fd7d9c"
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[19:26:23] WARNING: not removing hydrogen atom without neighbors\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Number of training samples: 5160\n",
-            "Number of test samples: 645\n",
-            "Epoch 1/100\n",
-            "\u001b[1m21/21\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m23s\u001b[0m 540ms/step - accuracy: 0.7075 - auc: 0.7846 - f1_score: 0.4252 - loss: 0.7072 - precision: 0.7075 - recall: 0.7075\n",
-            "Epoch 2/100\n",
-            "\u001b[1m21/21\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m12s\u001b[0m 577ms/step - accuracy: 0.6011 - auc: 0.6077 - f1_score: 0.4076 - loss: 0.6881 - precision: 0.6011 - recall: 0.6011\n",
-            "Epoch 3/100\n",
-            "\u001b[1m21/21\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m10s\u001b[0m 480ms/step - accuracy: 0.6849 - auc: 0.7427 - f1_score: 0.4461 - loss: 0.6743 - precision: 0.6849 - recall: 0.6849\n",
-            "Epoch 4/100\n",
-            "\u001b[1m21/21\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m12s\u001b[0m 563ms/step - accuracy: 0.7136 - auc: 0.7682 - f1_score: 0.4652 - loss: 0.6654 - precision: 0.7136 - recall: 0.7136\n",
-            "Epoch 5/100\n",
-            "\u001b[1m12/21\u001b[0m \u001b[32m━━━━━━━━━━━\u001b[0m\u001b[37m━━━━━━━━━\u001b[0m \u001b[1m5s\u001b[0m 624ms/step - accuracy: 0.7234 - auc: 0.7680 - f1_score: 0.4732 - loss: 0.6852 - precision: 0.7234 - recall: 0.7234"
-          ]
-        }
-      ],
-      "source": [
-        "# Convert to numpy arrays\n",
-        "XD_np = np.array(XD)\n",
-        "labels_np = np.array(labels)\n",
-        "\n",
-        "# Remove samples that don't have labels\n",
-        "index = ~np.isnan(labels_np)\n",
-        "labels_np = labels_np[index]\n",
-        "XD_np = XD_np[index]\n",
-        "\n",
-        "# Filter the corresponding SMILES\n",
-        "filtered_smiles = smiles.iloc[index].values\n",
-        "\n",
-        "# Create a Dataset using SMILES as identifiers\n",
-        "dataset = NumpyDataset(X=XD_np, y=labels_np, ids=filtered_smiles)\n",
-        "\n",
-        "# Create a ScaffoldSplitter\n",
-        "splitter = ScaffoldSplitter()\n",
-        "\n",
-        "# Split data into training, validation, and test sets\n",
-        "train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(\n",
-        "    dataset, frac_train=0.8, frac_valid=0.1, frac_test=0.1\n",
-        ")\n",
-        "\n",
-        "# Extract training and test indices\n",
-        "train_indices = train_dataset.ids\n",
-        "test_indices = test_dataset.ids\n",
-        "smiles_to_index = {smile: idx for idx, smile in enumerate(filtered_smiles)}\n",
-        "\n",
-        "# Convert SMILES to indices\n",
-        "train_indices = np.array([smiles_to_index[smile] for smile in train_indices])\n",
-        "test_indices = np.array([smiles_to_index[smile] for smile in test_indices])\n",
-        "\n",
-        "# Split the data based on the indices\n",
-        "X_train, X_test = XD_np[train_indices], XD_np[test_indices]\n",
-        "y_train, y_test = labels_np[train_indices], labels_np[test_indices]\n",
-        "\n",
-        "print(f\"Number of training samples: {X_train.shape[0]}\")\n",
-        "print(f\"Number of test samples: {X_test.shape[0]}\")\n",
-        "\n",
-        "\n",
-        "# Convert labels to categorical format\n",
-        "y_train_cat = to_categorical(y_train, num_classes=2)\n",
-        "y_test_cat = to_categorical(y_test, num_classes=2)\n",
-        "# Compute class weights to handle class imbalance\n",
-        "class_weights_array = compute_class_weight(\n",
-        "    class_weight='balanced',\n",
-        "    classes=np.unique(y_train),\n",
-        "    y=y_train.ravel()\n",
-        ")\n",
-        "class_weight = {\n",
-        "    0: class_weights_array[0],\n",
-        "    1: class_weights_array[1]\n",
-        "}\n",
-        "\n",
-        "# === Define Optimizer for Interaction Model ===\n",
-        "opt = optimizers.Adam(learning_rate=0.0001)\n",
-        "interactionModel.compile(optimizer=opt, loss=\"categorical_crossentropy\", metrics=METRICS_CATEGORICAL)\n",
-        "\n",
-        "# Define callbacks\n",
-        "early_stopping = EarlyStopping(monitor='loss', patience=30, verbose=1, mode='min', restore_best_weights=True)\n",
-        "reduce_lr = LearningRateScheduler(lambda epoch: 1e-3 * 0.9 ** epoch)\n",
-        "\n",
-        "# === Phase 1: Train Interaction Model ===\n",
-        "interactionModel.fit(\n",
-        "    X_train, y_train_cat,\n",
-        "    batch_size=256, epochs=100, class_weight=class_weight,\n",
-        "    callbacks=[early_stopping], verbose=1\n",
-        ")\n",
-        "\n",
-        "# Evaluate Phase 1 on test data\n",
-        "test_eval_phase1 = interactionModel.evaluate(X_test, y_test_cat, verbose=1)\n",
-        "\n",
-        "# === Feature Extraction ===\n",
-        "feature_train = model_feature.predict(X_train)\n",
-        "feature_test = model_feature.predict(X_test)\n",
-        "\n",
-        "# === Phase 2: Train Model Phase 2 ===\n",
-        "opt_phaz2 = optimizers.Adam(learning_rate=0.001)\n",
-        "model_phaz2.compile(optimizer=opt_phaz2, loss=\"binary_crossentropy\", metrics=METRICS_BINARY)\n",
-        "model_phaz2.fit(\n",
-        "    feature_train, y_train,\n",
-        "    batch_size=256, epochs=100,class_weight=class_weight,\n",
-        "    callbacks=[early_stopping], verbose=1\n",
-        ")\n",
-        "\n",
-        "# === Freeze Transformer Blocks ===\n",
-        "new_transformer_block.set_weights(transformer_block1.get_weights())\n",
-        "new_transformer_block2.set_weights(transformer_block2.get_weights())  \n",
-        "\n",
-        "# === Phase 3: Train Model Phase 3 ===\n",
-        "opt_phaz3 = optimizers.Adam(learning_rate=0.0001)\n",
-        "model_phaz3.compile(optimizer=opt_phaz3, loss=\"categorical_crossentropy\", metrics=METRICS_CATEGORICAL)\n",
-        "\n",
-        "model_phaz3.fit(\n",
-        "    X_train, y_train_cat,\n",
-        "    batch_size=256, epochs=100,class_weight=class_weight,\n",
-        "    callbacks=[early_stopping], verbose=1\n",
-        ")\n",
-        "\n",
-        "# Evaluate Phase 3 on both training and testing data\n",
-        "train_eval_phase3 = model_phaz3.evaluate(X_train, y_train_cat, verbose=1)\n",
-        "test_eval_phase3 = model_phaz3.evaluate(X_test, y_test_cat, verbose=1)\n",
-        "\n",
-        "# === Function to Format Results ===\n",
-        "def format_results(phase1_result, phase3_train_result, phase3_test_result):\n",
-        "    # Define Metric Names\n",
-        "    phase1_metrics = ['loss', 'accuracy', 'precision', 'recall', 'auc', 'f1_score']\n",
-        "    phase3_metrics = ['loss', 'accuracy', 'precision', 'recall', 'auc', 'f1_score']\n",
-        "\n",
-        "    # Create DataFrames\n",
-        "    phase1_test_df = pd.DataFrame([phase1_result], columns=phase1_metrics)\n",
-        "    phase3_train_df = pd.DataFrame([phase3_train_result], columns=phase3_metrics)\n",
-        "    phase3_test_df = pd.DataFrame([test_eval_phase3], columns=phase3_metrics)\n",
-        "\n",
-        "    # Display the Results\n",
-        "    print(\"\\n=== Phase 1: Test Evaluation Results ===\")\n",
-        "    print(phase1_test_df.to_string(index=False, float_format=lambda x: f\"{x:.4f}\"))\n",
-        "\n",
-        "    print(\"\\n=== Phase 3: Train Evaluation Results ===\")\n",
-        "    print(phase3_train_df.to_string(index=False, float_format=lambda x: f\"{x:.4f}\"))\n",
-        "\n",
-        "    print(\"\\n=== Phase 3: Test Evaluation Results ===\")\n",
-        "    print(phase3_test_df.to_string(index=False, float_format=lambda x: f\"{x:.4f}\"))\n",
-        "\n",
-        "\n",
-        "# === Display Results ===\n",
-        "format_results(test_eval_phase1, train_eval_phase3, test_eval_phase3)\n",
-        "\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.5"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "w71ntxmiP5Cs"
+   },
+   "source": [
+    "#Importing libraries"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "N2mc3-OTP210",
+    "outputId": "1bcf264f-343b-4610-b609-3c89f2b742f1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\tensorflow\\python\\util\\deprecation.py:588: calling function (from tensorflow.python.eager.polymorphic_function.polymorphic_function) with experimental_relax_shapes is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "experimental_relax_shapes is deprecated, use reduce_retracing instead\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import tensorflow as tf\n",
+    "import keras\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import LinearSegmentedColormap\n",
+    "\n",
+    "from sklearn.model_selection import StratifiedKFold, train_test_split, KFold\n",
+    "from sklearn.utils.class_weight import compute_class_weight\n",
+    "from sklearn.metrics import classification_report, confusion_matrix\n",
+    "\n",
+    "from tensorflow.keras import optimizers, layers, regularizers, metrics\n",
+    "from tensorflow.keras.layers import (\n",
+    "    Lambda, Input, Reshape, Activation, Concatenate, Dense, Dropout,\n",
+    "    BatchNormalization, Conv1D, GlobalMaxPooling1D, LayerNormalization, GlobalAveragePooling1D\n",
+    ")\n",
+    "from tensorflow.keras.models import Model\n",
+    "from tensorflow.keras.utils import to_categorical\n",
+    "from tensorflow.keras.callbacks import LearningRateScheduler, EarlyStopping\n",
+    "\n",
+    "from einops import rearrange, repeat\n",
+    "from einops.layers.tensorflow import Rearrange\n",
+    "from deepchem.data import NumpyDataset\n",
+    "from deepchem.splits import ScaffoldSplitter\n",
+    "from keras.layers import Conv1D, GlobalMaxPooling1D, MaxPooling1D"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AFGjtuURP7OE"
+   },
+   "source": [
+    "### Cloning a GitHub repository"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "S-xDZ16oP-4J",
+    "outputId": "ed8899b2-2a9e-4f4c-d520-e07eced6dba1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fatal: destination path 'Deep-CBN' already exists and is not an empty directory.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#!git clone https://github.com/akianfar/Deep-CBN.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DWrFzNjSQCtg"
+   },
+   "source": [
+    "### Loading and Preparing Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 241
+    },
+    "id": "kXFLqk2vja5M",
+    "outputId": "3e31a23d-130b-48c7-cfd4-bc76cd6c75bb"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>NR-AR</th>\n",
+       "      <th>NR-AR-LBD</th>\n",
+       "      <th>NR-AhR</th>\n",
+       "      <th>NR-Aromatase</th>\n",
+       "      <th>NR-ER</th>\n",
+       "      <th>NR-ER-LBD</th>\n",
+       "      <th>NR-PPAR-gamma</th>\n",
+       "      <th>SR-ARE</th>\n",
+       "      <th>SR-ATAD5</th>\n",
+       "      <th>SR-HSE</th>\n",
+       "      <th>SR-MMP</th>\n",
+       "      <th>SR-p53</th>\n",
+       "      <th>mol_id</th>\n",
+       "      <th>smiles</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>TOX3021</td>\n",
+       "      <td>CCOc1ccc2nc(S(N)(=O)=O)sc2c1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>TOX3020</td>\n",
+       "      <td>CCN1C(=O)NC(c2ccccc2)C1=O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>TOX3024</td>\n",
+       "      <td>CC[C@]1(O)CC[C@H]2[C@@H]3CCC4=CCCC[C@@H]4[C@H]...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>TOX3027</td>\n",
+       "      <td>CCCN(CC)C(CC)C(=O)Nc1c(C)cccc1C</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>TOX20800</td>\n",
+       "      <td>CC(O)(P(=O)(O)O)P(=O)(O)O</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   NR-AR  NR-AR-LBD  NR-AhR  NR-Aromatase  NR-ER  NR-ER-LBD  NR-PPAR-gamma  \\\n",
+       "0    0.0        0.0     1.0           NaN    NaN        0.0            0.0   \n",
+       "1    0.0        0.0     0.0           0.0    0.0        0.0            0.0   \n",
+       "2    NaN        NaN     NaN           NaN    NaN        NaN            NaN   \n",
+       "3    0.0        0.0     0.0           0.0    0.0        0.0            0.0   \n",
+       "4    0.0        0.0     0.0           0.0    0.0        0.0            0.0   \n",
+       "\n",
+       "   SR-ARE  SR-ATAD5  SR-HSE  SR-MMP  SR-p53    mol_id  \\\n",
+       "0     1.0       0.0     0.0     0.0     0.0   TOX3021   \n",
+       "1     NaN       0.0     NaN     0.0     0.0   TOX3020   \n",
+       "2     0.0       NaN     0.0     NaN     NaN   TOX3024   \n",
+       "3     NaN       0.0     NaN     0.0     0.0   TOX3027   \n",
+       "4     0.0       0.0     0.0     0.0     0.0  TOX20800   \n",
+       "\n",
+       "                                              smiles  \n",
+       "0                       CCOc1ccc2nc(S(N)(=O)=O)sc2c1  \n",
+       "1                          CCN1C(=O)NC(c2ccccc2)C1=O  \n",
+       "2  CC[C@]1(O)CC[C@H]2[C@@H]3CCC4=CCCC[C@@H]4[C@H]...  \n",
+       "3                    CCCN(CC)C(CC)C(=O)Nc1c(C)cccc1C  \n",
+       "4                          CC(O)(P(=O)(O)O)P(=O)(O)O  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = pd.read_csv('../Data/tox21.csv')\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "AFxos0tgQC9s"
+   },
+   "outputs": [],
+   "source": [
+    "smiles = data['smiles']\n",
+    "labels = data['NR-PPAR-gamma']\n",
+    "\n",
+    "# Dictionary to convert SMILES characters into numeric values\n",
+    "smiles_dict = {\n",
+    "    \"#\": 29, \"%\": 30, \")\": 31, \"(\": 1, \"+\": 32, \"-\": 33, \"/\": 34, \".\": 2,\n",
+    "    \"1\": 35, \"0\": 3, \"3\": 36, \"2\": 4, \"5\": 37, \"4\": 5, \"7\": 38, \"6\": 6,\n",
+    "    \"9\": 39, \"8\": 7, \"=\": 40, \"A\": 41, \"@\": 8, \"C\": 42, \"B\": 9, \"E\": 43,\n",
+    "    \"D\": 10, \"G\": 44, \"F\": 11, \"I\": 45, \"H\": 12, \"K\": 46, \"M\": 47, \"L\": 13,\n",
+    "    \"O\": 48, \"N\": 14, \"P\": 15, \"S\": 49, \"R\": 16, \"U\": 50, \"T\": 17, \"W\": 51,\n",
+    "    \"V\": 18, \"Y\": 52, \"[\": 53, \"Z\": 19, \"]\": 54, \"\\\\\": 20, \"a\": 55, \"c\": 56,\n",
+    "    \"b\": 21, \"e\": 57, \"d\": 22, \"g\": 58, \"f\": 23, \"i\": 59, \"h\": 24, \"m\": 60,\n",
+    "    \"l\": 25, \"o\": 61, \"n\": 26, \"s\": 62, \"r\": 27, \"u\": 63, \"t\": 28, \"y\": 64,\n",
+    "    \" \": 65, \":\": 66, \",\": 67, \"p\": 68, \"j\": 69, \"*\": 70\n",
+    "}\n",
+    "\n",
+    "def label_smiles(line, MAX_SMI_LEN, smi_ch_ind):\n",
+    "    X = np.zeros(MAX_SMI_LEN, dtype=int)\n",
+    "    for i, ch in enumerate(line[:MAX_SMI_LEN]):\n",
+    "        if ch in smi_ch_ind:\n",
+    "            X[i] = smi_ch_ind[ch]\n",
+    "    return X\n",
+    "\n",
+    "MAX_SMI_LEN = 100  # You can adjust this based on your needs\n",
+    "XD = np.array([label_smiles(str(smi), MAX_SMI_LEN, smiles_dict) for smi in smiles])\n",
+    "labels = labels.values\n",
+    "\n",
+    "# Convert to categorical\n",
+    "XD = to_categorical(XD, num_classes=71)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Qmjyj91JeXsG"
+   },
+   "source": [
+    "# phaze1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "id": "A2VgoLaMQN0X",
+    "outputId": "d183f5ed-45d0-496a-8aa7-9347ac07ec00"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"model_feature\"</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mModel: \"model_feature\"\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503<span style=\"font-weight: bold\"> Layer (type)                    </span>\u2503<span style=\"font-weight: bold\"> Output Shape           </span>\u2503<span style=\"font-weight: bold\">       Param # </span>\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 XDinput (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)            \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">100</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">71</span>)        \u2502             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 conv1d (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Conv1D</span>)                 \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">99</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)         \u2502         <span style=\"color: #00af00; text-decoration-color: #00af00\">9,152</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 conv1d_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Conv1D</span>)               \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">96</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)         \u2502        <span style=\"color: #00af00; text-decoration-color: #00af00\">16,448</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 conv1d_2 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Conv1D</span>)               \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)        \u2502        <span style=\"color: #00af00; text-decoration-color: #00af00\">32,896</span> \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503\u001b[1m \u001b[0m\u001b[1mLayer (type)                   \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1mOutput Shape          \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1m      Param #\u001b[0m\u001b[1m \u001b[0m\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 XDinput (\u001b[38;5;33mInputLayer\u001b[0m)            \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m100\u001b[0m, \u001b[38;5;34m71\u001b[0m)        \u2502             \u001b[38;5;34m0\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 conv1d (\u001b[38;5;33mConv1D\u001b[0m)                 \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m99\u001b[0m, \u001b[38;5;34m64\u001b[0m)         \u2502         \u001b[38;5;34m9,152\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 conv1d_1 (\u001b[38;5;33mConv1D\u001b[0m)               \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m96\u001b[0m, \u001b[38;5;34m64\u001b[0m)         \u2502        \u001b[38;5;34m16,448\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 conv1d_2 (\u001b[38;5;33mConv1D\u001b[0m)               \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)        \u2502        \u001b[38;5;34m32,896\u001b[0m \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">58,496</span> (228.50 KB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m58,496\u001b[0m (228.50 KB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">58,496</span> (228.50 KB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m58,496\u001b[0m (228.50 KB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (0.00 B)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m0\u001b[0m (0.00 B)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"functional\"</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mModel: \"functional\"\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503<span style=\"font-weight: bold\"> Layer (type)                    </span>\u2503<span style=\"font-weight: bold\"> Output Shape           </span>\u2503<span style=\"font-weight: bold\">       Param # </span>\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 input_layer (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)        \u2502             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                   \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)        \u2502        <span style=\"color: #00af00; text-decoration-color: #00af00\">66,048</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 batch_normalization             \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)        \u2502         <span style=\"color: #00af00; text-decoration-color: #00af00\">2,048</span> \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">BatchNormalization</span>)            \u2502                        \u2502               \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dropout (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)               \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)        \u2502             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                 \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)        \u2502       <span style=\"color: #00af00; text-decoration-color: #00af00\">131,328</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 batch_normalization_1           \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)        \u2502         <span style=\"color: #00af00; text-decoration-color: #00af00\">1,024</span> \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">BatchNormalization</span>)            \u2502                        \u2502               \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dropout_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)             \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)        \u2502             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_2 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                 \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)         \u2502        <span style=\"color: #00af00; text-decoration-color: #00af00\">16,448</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_3 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)                 \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)          \u2502           <span style=\"color: #00af00; text-decoration-color: #00af00\">130</span> \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503\u001b[1m \u001b[0m\u001b[1mLayer (type)                   \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1mOutput Shape          \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1m      Param #\u001b[0m\u001b[1m \u001b[0m\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 input_layer (\u001b[38;5;33mInputLayer\u001b[0m)        \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)        \u2502             \u001b[38;5;34m0\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense (\u001b[38;5;33mDense\u001b[0m)                   \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m512\u001b[0m)        \u2502        \u001b[38;5;34m66,048\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 batch_normalization             \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m512\u001b[0m)        \u2502         \u001b[38;5;34m2,048\u001b[0m \u2502\n",
+       "\u2502 (\u001b[38;5;33mBatchNormalization\u001b[0m)            \u2502                        \u2502               \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dropout (\u001b[38;5;33mDropout\u001b[0m)               \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m512\u001b[0m)        \u2502             \u001b[38;5;34m0\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_1 (\u001b[38;5;33mDense\u001b[0m)                 \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m256\u001b[0m)        \u2502       \u001b[38;5;34m131,328\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 batch_normalization_1           \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m256\u001b[0m)        \u2502         \u001b[38;5;34m1,024\u001b[0m \u2502\n",
+       "\u2502 (\u001b[38;5;33mBatchNormalization\u001b[0m)            \u2502                        \u2502               \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dropout_1 (\u001b[38;5;33mDropout\u001b[0m)             \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m256\u001b[0m)        \u2502             \u001b[38;5;34m0\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_2 (\u001b[38;5;33mDense\u001b[0m)                 \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m64\u001b[0m)         \u2502        \u001b[38;5;34m16,448\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_3 (\u001b[38;5;33mDense\u001b[0m)                 \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m2\u001b[0m)          \u2502           \u001b[38;5;34m130\u001b[0m \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">217,026</span> (847.76 KB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m217,026\u001b[0m (847.76 KB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">215,490</span> (841.76 KB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m215,490\u001b[0m (841.76 KB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">1,536</span> (6.00 KB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m1,536\u001b[0m (6.00 KB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"interactionModel\"</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mModel: \"interactionModel\"\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503<span style=\"font-weight: bold\"> Layer (type)                    </span>\u2503<span style=\"font-weight: bold\"> Output Shape           </span>\u2503<span style=\"font-weight: bold\">       Param # </span>\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 XDinput (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)            \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">100</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">71</span>)        \u2502             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 model_feature (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Functional</span>)      \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)        \u2502        <span style=\"color: #00af00; text-decoration-color: #00af00\">58,496</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 functional (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Functional</span>)         \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)          \u2502       <span style=\"color: #00af00; text-decoration-color: #00af00\">217,026</span> \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 global_average_pooling1d        \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)              \u2502             <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">GlobalAveragePooling1D</span>)        \u2502                        \u2502               \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503\u001b[1m \u001b[0m\u001b[1mLayer (type)                   \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1mOutput Shape          \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1m      Param #\u001b[0m\u001b[1m \u001b[0m\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 XDinput (\u001b[38;5;33mInputLayer\u001b[0m)            \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m100\u001b[0m, \u001b[38;5;34m71\u001b[0m)        \u2502             \u001b[38;5;34m0\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 model_feature (\u001b[38;5;33mFunctional\u001b[0m)      \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)        \u2502        \u001b[38;5;34m58,496\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 functional (\u001b[38;5;33mFunctional\u001b[0m)         \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m2\u001b[0m)          \u2502       \u001b[38;5;34m217,026\u001b[0m \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 global_average_pooling1d        \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2\u001b[0m)              \u2502             \u001b[38;5;34m0\u001b[0m \u2502\n",
+       "\u2502 (\u001b[38;5;33mGlobalAveragePooling1D\u001b[0m)        \u2502                        \u2502               \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">275,522</span> (1.05 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m275,522\u001b[0m (1.05 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">273,986</span> (1.05 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m273,986\u001b[0m (1.05 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">1,536</span> (6.00 KB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m1,536\u001b[0m (6.00 KB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Feature model definition \n",
+    "XDinput = Input(shape=(100, 71), name='XDinput')\n",
+    "encode_smiles = Conv1D(filters=64, kernel_size=2, activation='relu', padding='valid', strides=1)(XDinput)  # (99,64)\n",
+    "encode_smiles = Conv1D(filters=64, kernel_size=4, activation='relu', padding='valid', strides=1)(encode_smiles)  # (96,64)\n",
+    "encode_smiles = Conv1D(filters=128, kernel_size=4, activation='relu', padding='valid', strides=1)(encode_smiles)  # (93,128)\n",
+    "model_feature = Model(inputs=XDinput, outputs=encode_smiles, name='model_feature')\n",
+    "model_feature.summary()\n",
+    "\n",
+    "# Prediction model definition\n",
+    "input_extracted_feature = Input(shape=(93, 128))\n",
+    "FC1 = Dense(512, activation='relu')(input_extracted_feature)\n",
+    "FC1 = BatchNormalization()(FC1)\n",
+    "FC2 = Dropout(0.1)(FC1)\n",
+    "FC3 = Dense(256, activation='relu')(FC2)\n",
+    "FC3 = BatchNormalization()(FC3)\n",
+    "FC4 = Dropout(0.1)(FC3)\n",
+    "FC5 = Dense(64, activation='relu')(FC4)\n",
+    "predictions = Dense(2, activation='softmax')(FC5)\n",
+    "model_pred = Model(inputs=input_extracted_feature, outputs=predictions)\n",
+    "model_pred.summary()\n",
+    "\n",
+    "# Full model definition with added Pooling layer\n",
+    "interaction_input = XDinput\n",
+    "encoded_features = model_feature(interaction_input)  # Output: (None, 93, 128)\n",
+    "predicted_output = model_pred(encoded_features)      # Output: (None, 93, 2)\n",
+    "\n",
+    "# Adding Pooling layer to reduce dimensionality\n",
+    "pooled_output = GlobalAveragePooling1D()(predicted_output)  # Output: (None, 2)\n",
+    "\n",
+    "# Final model definition\n",
+    "interactionModel = Model(inputs=interaction_input, outputs=pooled_output, name='interactionModel')\n",
+    "interactionModel.summary()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "KW4Dc7MfQWbn"
+   },
+   "source": [
+    "### BiFormer Block\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "C5EAZalFQWpH"
+   },
+   "outputs": [],
+   "source": [
+    "# Define custom layers for 1D processing\n",
+    "class TopkRouting(layers.Layer):\n",
+    "    def __init__(self, qk_dim, topk=16, qk_scale=None, param_routing=False, diff_routing=False):\n",
+    "        super().__init__()\n",
+    "        self.topk = topk\n",
+    "        self.qk_dim = qk_dim\n",
+    "        self.scale = qk_scale if qk_scale is not None else qk_dim**-0.5\n",
+    "        self.diff_routing = diff_routing\n",
+    "        if param_routing:\n",
+    "            self.emb = layers.Dense(qk_dim)\n",
+    "        else:\n",
+    "            self.emb = lambda x: x\n",
+    "        self.routing_act = lambda x, axis: tf.nn.softmax(x, axis=axis)\n",
+    "\n",
+    "    def call(self, query, key, training=None):\n",
+    "        if not self.diff_routing:\n",
+    "            query = tf.stop_gradient(query)\n",
+    "            key = tf.stop_gradient(key)\n",
+    "        query_hat = self.emb(query)\n",
+    "        key_hat = self.emb(key)\n",
+    "\n",
+    "        attn_logit = tf.einsum('bnc,bqc->bnq', query_hat*self.scale, key_hat)  # Adjusted for 1D\n",
+    "        topk_attn_logit, topk_index = tf.math.top_k(attn_logit, k=self.topk, sorted=True)\n",
+    "        r_weight = self.routing_act(topk_attn_logit, axis=-1)\n",
+    "        return r_weight, topk_index\n",
+    "\n",
+    "def tf_gather_kv(kv, r_idx):\n",
+    "    n = tf.shape(kv)[0]\n",
+    "    p2 = tf.shape(kv)[1]\n",
+    "    c_kv = tf.shape(kv)[2]\n",
+    "    topk = tf.shape(r_idx)[2]\n",
+    "\n",
+    "    batch_idx = tf.reshape(tf.range(n), [n, 1, 1])\n",
+    "    batch_idx = tf.tile(batch_idx, [1, p2, topk])\n",
+    "    p2_idx = tf.reshape(tf.range(p2), [1, p2, 1])\n",
+    "    p2_idx = tf.tile(p2_idx, [n, 1, topk])\n",
+    "\n",
+    "    gather_indices = tf.stack([batch_idx, p2_idx, r_idx], axis=-1)\n",
+    "    gathered = tf.gather_nd(kv, gather_indices)\n",
+    "    return gathered  # Shape: (n, p2, topk, c_kv)\n",
+    "\n",
+    "class KVGather(layers.Layer):\n",
+    "    def __init__(self, mul_weight='none'):\n",
+    "        super().__init__()\n",
+    "        assert mul_weight in ['none', 'soft', 'hard']\n",
+    "        self.mul_weight = mul_weight\n",
+    "\n",
+    "    def call(self, r_idx, r_weight, kv, training=None):\n",
+    "        topk_kv = tf_gather_kv(kv, r_idx)\n",
+    "        if self.mul_weight == 'soft':\n",
+    "            r_weight_exp = tf.expand_dims(tf.expand_dims(r_weight, -1), -1)\n",
+    "            topk_kv = topk_kv * r_weight_exp\n",
+    "        return topk_kv\n",
+    "\n",
+    "class QKVLinear(layers.Layer):\n",
+    "    def __init__(self, dim, qk_dim, bias=True):\n",
+    "        super().__init__()\n",
+    "        self.dim = dim\n",
+    "        self.qk_dim = qk_dim\n",
+    "        self.qkv = layers.Dense(qk_dim + qk_dim + dim, use_bias=bias)\n",
+    "\n",
+    "    def call(self, x, training=None):\n",
+    "        qkv = self.qkv(x)\n",
+    "        q, kv = tf.split(qkv, [self.qk_dim, self.qk_dim + self.dim], axis=-1)\n",
+    "        return q, kv\n",
+    "\n",
+    "class BiLevelRoutingAttention(layers.Layer):\n",
+    "    def __init__(self, dim, n_win=7, num_heads=8, qk_dim=None, qk_scale=None,\n",
+    "                 kv_per_win=4, kv_downsample_ratio=4, kv_downsample_mode='identity',\n",
+    "                 topk=4, param_attention=\"qkvo\", param_routing=False, diff_routing=False, soft_routing=False,\n",
+    "                 side_dwconv=3, auto_pad=True):\n",
+    "        super().__init__()\n",
+    "        self.dim = dim\n",
+    "        self.n_win = n_win\n",
+    "        self.num_heads = num_heads\n",
+    "        self.qk_dim = qk_dim if qk_dim is not None else dim\n",
+    "        self.scale = qk_scale if qk_scale is not None else self.qk_dim**-0.5\n",
+    "        self.topk = topk\n",
+    "        self.param_routing = param_routing\n",
+    "        self.diff_routing = diff_routing\n",
+    "        self.soft_routing = soft_routing\n",
+    "        self.auto_pad = auto_pad\n",
+    "\n",
+    "        # For 1D, we use Conv1D\n",
+    "        if side_dwconv > 0:\n",
+    "            self.lepe = layers.Conv1D(dim, kernel_size=side_dwconv, padding='same', activation='relu')\n",
+    "        else:\n",
+    "            self.lepe = lambda x: tf.zeros_like(x)\n",
+    "\n",
+    "        self.router = TopkRouting(qk_dim=self.qk_dim, topk=self.topk, qk_scale=self.scale,\n",
+    "                                  param_routing=self.param_routing, diff_routing=self.diff_routing)\n",
+    "\n",
+    "        mul_weight = 'none'\n",
+    "        if self.soft_routing:\n",
+    "            mul_weight = 'soft'\n",
+    "        self.kv_gather = KVGather(mul_weight=mul_weight)\n",
+    "\n",
+    "        if param_attention in ['qkvo', 'qkv']:\n",
+    "            self.qkv = QKVLinear(self.dim, self.qk_dim)\n",
+    "            if param_attention == 'qkvo':\n",
+    "                self.wo = layers.Dense(self.dim)\n",
+    "            else:\n",
+    "                self.wo = lambda x: x\n",
+    "        else:\n",
+    "            raise ValueError(\"Unsupported param_attention mode\")\n",
+    "\n",
+    "        self.attn_act = lambda x: tf.nn.softmax(x, axis=-1)\n",
+    "        self.kv_down = lambda x: x  # identity for simplicity\n",
+    "\n",
+    "    def call(self, x, training=None, ret_attn_mask=False):\n",
+    "        # Implementing full attention can be complex, so here we only keep the general structure\n",
+    "        if ret_attn_mask:\n",
+    "            return x, None, None, None\n",
+    "        else:\n",
+    "            return x\n",
+    "\n",
+    "class Attention(layers.Layer):\n",
+    "    def __init__(self, dim, num_heads=8, qkv_bias=False, qk_scale=None, attn_drop=0., proj_drop=0.):\n",
+    "        super().__init__()\n",
+    "        self.num_heads = num_heads\n",
+    "        head_dim = dim // num_heads\n",
+    "        self.scale = qk_scale if qk_scale is not None else head_dim**-0.5\n",
+    "        self.qkv = layers.Dense(dim*3, use_bias=qkv_bias)\n",
+    "        self.attn_drop = layers.Dropout(attn_drop)\n",
+    "        self.proj = layers.Dense(dim)\n",
+    "        self.proj_drop = layers.Dropout(proj_drop)\n",
+    "\n",
+    "    def call(self, x, training=None):\n",
+    "        batch_size, seq_length, dim = tf.unstack(tf.shape(x))\n",
+    "        qkv = self.qkv(x)\n",
+    "        q, k, v = tf.split(qkv, 3, axis=-1)\n",
+    "        q = rearrange(q, 'b s (h d) -> b h s d', h=self.num_heads)\n",
+    "        k = rearrange(k, 'b s (h d) -> b h s d', h=self.num_heads)\n",
+    "        v = rearrange(v, 'b s (h d) -> b h s d', h=self.num_heads)\n",
+    "\n",
+    "        attn = tf.einsum('bhid,bhjd->bhij', q, k) * self.scale\n",
+    "        attn = tf.nn.softmax(attn, axis=-1)\n",
+    "        attn = self.attn_drop(attn, training=training)\n",
+    "        out = tf.einsum('bhij,bhjd->bhid', attn, v)\n",
+    "        out = rearrange(out, 'b h s d -> b s (h d)')\n",
+    "        out = self.proj(out)\n",
+    "        out = self.proj_drop(out, training=training)\n",
+    "        return out\n",
+    "\n",
+    "class AttentionLePE(layers.Layer):\n",
+    "    def __init__(self, dim, num_heads=8, qkv_bias=False, qk_scale=None, attn_drop=0., proj_drop=0., side_dwconv=5):\n",
+    "        super().__init__()\n",
+    "        self.num_heads = num_heads\n",
+    "        head_dim = dim // num_heads\n",
+    "        self.scale = qk_scale if qk_scale is not None else head_dim**-0.5\n",
+    "        self.qkv = layers.Dense(dim*3, use_bias=qkv_bias)\n",
+    "        self.attn_drop = layers.Dropout(attn_drop)\n",
+    "        self.proj = layers.Dense(dim)\n",
+    "        self.proj_drop = layers.Dropout(proj_drop)\n",
+    "        if side_dwconv > 0:\n",
+    "            self.lepe = layers.Conv1D(dim, kernel_size=side_dwconv, padding='same', activation='relu')\n",
+    "        else:\n",
+    "            self.lepe = lambda x: tf.zeros_like(x)\n",
+    "\n",
+    "    def call(self, x, training=None):\n",
+    "        lepe_out = self.lepe(x)\n",
+    "        qkv = self.qkv(x)\n",
+    "        q, k, v = tf.split(qkv, 3, axis=-1)\n",
+    "        q = rearrange(q, 'b s (h d) -> b h s d', h=self.num_heads)\n",
+    "        k = rearrange(k, 'b s (h d) -> b h s d', h=self.num_heads)\n",
+    "        v = rearrange(v, 'b s (h d) -> b h s d', h=self.num_heads)\n",
+    "\n",
+    "        attn = tf.einsum('bhid,bhjd->bhij', q, k) * self.scale\n",
+    "        attn = tf.nn.softmax(attn, axis=-1)\n",
+    "        attn = self.attn_drop(attn, training=training)\n",
+    "        out = tf.einsum('bhij,bhjd->bhid', attn, v)\n",
+    "        out = rearrange(out, 'b h s d -> b s (h d)')\n",
+    "        out = out + lepe_out\n",
+    "        out = self.proj(out)\n",
+    "        out = self.proj_drop(out, training=training)\n",
+    "        return out\n",
+    "\n",
+    "class PreNorm(layers.Layer):\n",
+    "    def __init__(self, fn):\n",
+    "        super(PreNorm, self).__init__()\n",
+    "        self.norm = layers.LayerNormalization()\n",
+    "        self.fn = fn\n",
+    "\n",
+    "    def call(self, x, training=True):\n",
+    "        return self.fn(self.norm(x), training=training)\n",
+    "\n",
+    "class MLP(layers.Layer):\n",
+    "    def __init__(self, dim, hidden_dim, dropout=0.2):\n",
+    "        super(MLP, self).__init__()\n",
+    "        self.net = keras.Sequential([\n",
+    "            layers.Dense(hidden_dim),\n",
+    "            layers.Activation('gelu'),\n",
+    "            layers.Dropout(rate=dropout),\n",
+    "            layers.Dense(dim),\n",
+    "            layers.Dropout(rate=dropout)\n",
+    "        ])\n",
+    "\n",
+    "    def call(self, x, training=True):\n",
+    "        return self.net(x, training=training)\n",
+    "\n",
+    "class DropPath(layers.Layer):\n",
+    "    # Placeholder for DropPath, currently no-op\n",
+    "    def __init__(self, drop_prob=0.):\n",
+    "        super().__init__()\n",
+    "        self.drop_prob = drop_prob\n",
+    "\n",
+    "    def call(self, x, training=None):\n",
+    "        if (not training) or self.drop_prob == 0.:\n",
+    "            return x\n",
+    "        keep_prob = 1 - self.drop_prob\n",
+    "        random_tensor = keep_prob\n",
+    "        random_tensor += tf.random.uniform(tf.shape(x), dtype=x.dtype)\n",
+    "        binary_tensor = tf.floor(random_tensor)\n",
+    "        return tf.divide(x, keep_prob) * binary_tensor\n",
+    "\n",
+    "class Block(layers.Layer):\n",
+    "    def __init__(self, dim, drop_path=0.1, layer_scale_init_value=-1,\n",
+    "                 num_heads=8, n_win=7, qk_dim=128, qk_scale=None,\n",
+    "                 kv_per_win=8, kv_downsample_ratio=1, kv_downsample_mode='identity',\n",
+    "                 topk=8, param_attention=\"qkvo\", param_routing=True, diff_routing=False, soft_routing=True,\n",
+    "                 mlp_ratio=4, mlp_dwconv=False, side_dwconv=5, before_attn_dwconv=3, pre_norm=True, auto_pad=True):\n",
+    "        super().__init__()\n",
+    "        qk_dim = qk_dim or dim\n",
+    "\n",
+    "        # For 1D, we use Conv1D\n",
+    "        if before_attn_dwconv > 0:\n",
+    "            self.pos_embed = layers.Conv1D(dim, kernel_size=before_attn_dwconv, padding='same', activation='relu')\n",
+    "        else:\n",
+    "            self.pos_embed = lambda x: tf.zeros_like(x)\n",
+    "\n",
+    "        self.norm1 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "\n",
+    "        if topk > 0:\n",
+    "            self.attn = BiLevelRoutingAttention(dim=dim, num_heads=num_heads, n_win=n_win, qk_dim=qk_dim,\n",
+    "                                               qk_scale=qk_scale, kv_per_win=kv_per_win, kv_downsample_ratio=kv_downsample_ratio,\n",
+    "                                               kv_downsample_mode=kv_downsample_mode, topk=topk, param_attention=param_attention,\n",
+    "                                               param_routing=param_routing, diff_routing=diff_routing, soft_routing=soft_routing,\n",
+    "                                               side_dwconv=side_dwconv, auto_pad=auto_pad)\n",
+    "        elif topk == -1:\n",
+    "            self.attn = Attention(dim=dim, num_heads=num_heads, qk_scale=qk_scale)\n",
+    "        elif topk == -2:\n",
+    "            self.attn = AttentionLePE(dim=dim, num_heads=num_heads, qk_scale=qk_scale, side_dwconv=side_dwconv)\n",
+    "        elif topk == 0:\n",
+    "            # Pseudo attention\n",
+    "            self.attn = keras.Sequential([\n",
+    "                layers.Dense(dim),\n",
+    "                layers.Conv1D(dim, kernel_size=5, padding='same', activation='relu'),\n",
+    "                layers.Dense(dim)\n",
+    "            ])\n",
+    "\n",
+    "        self.norm2 = layers.LayerNormalization(epsilon=1e-6)\n",
+    "\n",
+    "        mlp_hidden_dim = int(mlp_ratio * dim)\n",
+    "        mlp_layers = [layers.Dense(mlp_hidden_dim)]\n",
+    "        if mlp_dwconv:\n",
+    "            mlp_layers.append(layers.Conv1D(mlp_hidden_dim, kernel_size=3, padding='same', activation='relu'))\n",
+    "        mlp_layers.append(layers.Activation('gelu'))\n",
+    "        mlp_layers.append(layers.Dense(dim))\n",
+    "        mlp_layers.insert(1, layers.Dropout(0.2)) # Add dropout after first Dense\n",
+    "        mlp_layers.append(layers.Dropout(0.2))\n",
+    "        self.mlp = keras.Sequential(mlp_layers)\n",
+    "\n",
+    "        self.drop_path = DropPath(drop_path) if drop_path > 0. else layers.Lambda(lambda x: x)\n",
+    "\n",
+    "        if layer_scale_init_value > 0:\n",
+    "            self.use_layer_scale = True\n",
+    "            self.gamma1 = self.add_weight(shape=(dim,),\n",
+    "                                          initializer=tf.keras.initializers.Constant(layer_scale_init_value),\n",
+    "                                          trainable=True)\n",
+    "            self.gamma2 = self.add_weight(shape=(dim,),\n",
+    "                                          initializer=tf.keras.initializers.Constant(layer_scale_init_value),\n",
+    "                                          trainable=True)\n",
+    "        else:\n",
+    "            self.use_layer_scale = False\n",
+    "\n",
+    "        self.pre_norm = pre_norm\n",
+    "\n",
+    "    def call(self, x, training=None):\n",
+    "        x = x + self.pos_embed(x)  # Add positional embedding\n",
+    "\n",
+    "        if self.pre_norm:\n",
+    "            if self.use_layer_scale:\n",
+    "                x = x + self.drop_path(self.gamma1 * self.attn(self.norm1(x), training=training), training=training)\n",
+    "                x = x + self.drop_path(self.gamma2 * self.mlp(self.norm2(x), training=training), training=training)\n",
+    "            else:\n",
+    "                x = x + self.drop_path(self.attn(self.norm1(x), training=training), training=training)\n",
+    "                x = x + self.drop_path(self.mlp(self.norm2(x), training=training), training=training)\n",
+    "        else:\n",
+    "            if self.use_layer_scale:\n",
+    "                tmp = x + self.drop_path(self.gamma1 * self.attn(x, training=training), training=training)\n",
+    "                x = self.norm1(tmp)\n",
+    "                tmp = x + self.drop_path(self.gamma2 * self.mlp(x, training=training), training=training)\n",
+    "                x = self.norm2(tmp)\n",
+    "            else:\n",
+    "                tmp = x + self.drop_path(self.attn(x, training=training), training=training)\n",
+    "                x = self.norm1(tmp)\n",
+    "                tmp = x + self.drop_path(self.mlp(x, training=training), training=training)\n",
+    "                x = self.norm2(tmp)\n",
+    "\n",
+    "        return x\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "k41fqbmrQxbV"
+   },
+   "source": [
+    "# phaze2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 599
+    },
+    "id": "qFxfd5e4QdV3",
+    "outputId": "3ffefc83-bb87-45ff-cb54-e4535be8d055"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\backend\\tensorflow\\core.py:232: The name tf.placeholder is deprecated. Please use tf.compat.v1.placeholder instead.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\layers\\layer.py:421: UserWarning: `build()` was called on layer 'bi_level_routing_attention', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.\n",
+      "  warnings.warn(\n",
+      "c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\layers\\layer.py:421: UserWarning: `build()` was called on layer 'bi_level_routing_attention_1', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"functional_3\"</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mModel: \"functional_3\"\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503<span style=\"font-weight: bold\"> Layer (type)        </span>\u2503<span style=\"font-weight: bold\"> Output Shape      </span>\u2503<span style=\"font-weight: bold\">    Param # </span>\u2503<span style=\"font-weight: bold\"> Connected to      </span>\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 input_layer_1       \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 -                 \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 block (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Block</span>)       \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   \u2502    <span style=\"color: #00af00; text-decoration-color: #00af00\">148,608</span> \u2502 input_layer_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 block_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Block</span>)     \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   \u2502    <span style=\"color: #00af00; text-decoration-color: #00af00\">148,608</span> \u2502 input_layer_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 lambda (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)     \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)     \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 block[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]       \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 lambda_1 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)   \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)     \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 block_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]     \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 concatenate         \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)     \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 lambda[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>],     \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Concatenate</span>)       \u2502                   \u2502            \u2502 lambda_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 global_average_poo\u2026 \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)         \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 concatenate[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>] \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">GlobalAveragePool\u2026</span> \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 difference (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>) \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)         \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 global_average_p\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 activation_11       \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)         \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 difference[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]  \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Activation</span>)        \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503\u001b[1m \u001b[0m\u001b[1mLayer (type)       \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1mOutput Shape     \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1m   Param #\u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1mConnected to     \u001b[0m\u001b[1m \u001b[0m\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 input_layer_1       \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   \u2502          \u001b[38;5;34m0\u001b[0m \u2502 -                 \u2502\n",
+       "\u2502 (\u001b[38;5;33mInputLayer\u001b[0m)        \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 block (\u001b[38;5;33mBlock\u001b[0m)       \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   \u2502    \u001b[38;5;34m148,608\u001b[0m \u2502 input_layer_1[\u001b[38;5;34m0\u001b[0m]\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 block_1 (\u001b[38;5;33mBlock\u001b[0m)     \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   \u2502    \u001b[38;5;34m148,608\u001b[0m \u2502 input_layer_1[\u001b[38;5;34m0\u001b[0m]\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 lambda (\u001b[38;5;33mLambda\u001b[0m)     \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m1\u001b[0m)     \u2502          \u001b[38;5;34m0\u001b[0m \u2502 block[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]       \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 lambda_1 (\u001b[38;5;33mLambda\u001b[0m)   \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m1\u001b[0m)     \u2502          \u001b[38;5;34m0\u001b[0m \u2502 block_1[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]     \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 concatenate         \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m2\u001b[0m)     \u2502          \u001b[38;5;34m0\u001b[0m \u2502 lambda[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m],     \u2502\n",
+       "\u2502 (\u001b[38;5;33mConcatenate\u001b[0m)       \u2502                   \u2502            \u2502 lambda_1[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 global_average_poo\u2026 \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2\u001b[0m)         \u2502          \u001b[38;5;34m0\u001b[0m \u2502 concatenate[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m] \u2502\n",
+       "\u2502 (\u001b[38;5;33mGlobalAveragePool\u2026\u001b[0m \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 difference (\u001b[38;5;33mLambda\u001b[0m) \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m1\u001b[0m)         \u2502          \u001b[38;5;34m0\u001b[0m \u2502 global_average_p\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 activation_11       \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m1\u001b[0m)         \u2502          \u001b[38;5;34m0\u001b[0m \u2502 difference[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]  \u2502\n",
+       "\u2502 (\u001b[38;5;33mActivation\u001b[0m)        \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">297,216</span> (1.13 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m297,216\u001b[0m (1.13 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">297,216</span> (1.13 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m297,216\u001b[0m (1.13 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (0.00 B)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m0\u001b[0m (0.00 B)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Parameter settings for the block\n",
+    "dim = 128   \n",
+    "num_heads = 8\n",
+    "mlp_dim = 128 * 3  \n",
+    "depth = 2\n",
+    "dim_head = 48\n",
+    "\n",
+    "# Create Phase 2 model\n",
+    "input_phaz2 = Input(shape=(93, 128))  \n",
+    "\n",
+    "processed_input = input_phaz2\n",
+    "\n",
+    "# Define transformer blocks\n",
+    "transformer_block1 = Block(dim=dim, drop_path=0.2, num_heads=num_heads, topk=16, mlp_ratio=3)\n",
+    "transformer_block2 = Block(dim=dim, drop_path=0.2, num_heads=num_heads, topk=16, mlp_ratio=3)\n",
+    "\n",
+    "# Apply the first transformer block\n",
+    "transformer_output1 = transformer_block1(processed_input)\n",
+    "# Compute the norm of the output along the last axis (preserving dimensions)\n",
+    "transformer_output1 = Lambda(lambda x: tf.norm(x, axis=-1, keepdims=True))(transformer_output1)\n",
+    "\n",
+    "# Apply the second transformer block\n",
+    "transformer_output2 = transformer_block2(processed_input)\n",
+    "# Compute the norm of the output along the last axis (preserving dimensions)\n",
+    "transformer_output2 = Lambda(lambda x: tf.norm(x, axis=-1, keepdims=True))(transformer_output2)\n",
+    "\n",
+    "# Combine the outputs of both transformer blocks along the last axis\n",
+    "combined_outputs = Concatenate(axis=-1)([transformer_output1, transformer_output2])\n",
+    "\n",
+    "# Apply global average pooling to reduce the output to (batch_size, 2)\n",
+    "pooled_outputs = GlobalAveragePooling1D()(combined_outputs)\n",
+    "\n",
+    "# Compute the difference between the two pooled outputs and reshape to (batch_size, 1)\n",
+    "difference = Lambda(lambda x: tf.expand_dims(x[:, 0] - x[:, 1], axis=-1), name='difference')(pooled_outputs)\n",
+    "\n",
+    "# Apply sigmoid activation to normalize the output to the range [0, 1]\n",
+    "condition_2 = Activation('sigmoid', name='activation_11')(difference)\n",
+    "\n",
+    "# Freeze the `model_feature` layers to prevent them from being trained\n",
+    "model_feature.trainable = False\n",
+    "\n",
+    "# Define the complete model\n",
+    "model_phaz2 = Model(inputs=input_phaz2, outputs=condition_2)\n",
+    "model_phaz2.summary()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HcH6Y5x1e5OS"
+   },
+   "source": [
+    "# phaze3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "id": "F6DTjT17Q1W5",
+    "outputId": "6bcfc3f8-eeee-418e-cddd-31ff826c0ff5"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\layers\\layer.py:421: UserWarning: `build()` was called on layer 'bi_level_routing_attention_2', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.\n",
+      "  warnings.warn(\n",
+      "c:\\Users\\Scott.Coffin\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\keras\\src\\layers\\layer.py:421: UserWarning: `build()` was called on layer 'bi_level_routing_attention_3', however the layer does not have a `build()` method implemented and it looks like it has unbuilt state. This will cause the layer to be marked as built, despite not being actually built, which may cause failures down the line. Make sure to implement a proper `build()` method.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "input_layer_4 True\n",
+      "model_feature False\n",
+      "block_2 False\n",
+      "block_3 False\n",
+      "lambda_2 True\n",
+      "lambda_3 True\n",
+      "concatenate_1 True\n",
+      "global_average_pooling1d_2 True\n",
+      "dense_24 True\n",
+      "batch_normalization_2 True\n",
+      "dropout_10 True\n",
+      "dense_25 True\n",
+      "batch_normalization_3 True\n",
+      "dropout_11 True\n",
+      "dense_26 True\n",
+      "dense_27 True\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"functional_6\"</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1mModel: \"functional_6\"\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503<span style=\"font-weight: bold\"> Layer (type)        </span>\u2503<span style=\"font-weight: bold\"> Output Shape      </span>\u2503<span style=\"font-weight: bold\">    Param # </span>\u2503<span style=\"font-weight: bold\"> Connected to      </span>\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 input_layer_4       \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">100</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">71</span>)   \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 -                 \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 model_feature       \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   \u2502     <span style=\"color: #00af00; text-decoration-color: #00af00\">58,496</span> \u2502 input_layer_4[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]\u2026 \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Functional</span>)        \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 block_2 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Block</span>)     \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   \u2502    <span style=\"color: #00af00; text-decoration-color: #00af00\">148,608</span> \u2502 model_feature[<span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>]\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 block_3 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Block</span>)     \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">128</span>)   \u2502    <span style=\"color: #00af00; text-decoration-color: #00af00\">148,608</span> \u2502 model_feature[<span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>]\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 lambda_2 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)   \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)     \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 block_2[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]     \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 lambda_3 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Lambda</span>)   \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)     \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 block_3[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]     \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 concatenate_1       \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">93</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)     \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 lambda_2[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>],   \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Concatenate</span>)       \u2502                   \u2502            \u2502 lambda_3[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 global_average_poo\u2026 \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)         \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 concatenate_1[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]\u2026 \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">GlobalAveragePool\u2026</span> \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_24 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)    \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)       \u2502      <span style=\"color: #00af00; text-decoration-color: #00af00\">1,536</span> \u2502 global_average_p\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 batch_normalizatio\u2026 \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)       \u2502      <span style=\"color: #00af00; text-decoration-color: #00af00\">2,048</span> \u2502 dense_24[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">BatchNormalizatio\u2026</span> \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dropout_10          \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">512</span>)       \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 batch_normalizat\u2026 \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)           \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_25 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)    \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)       \u2502    <span style=\"color: #00af00; text-decoration-color: #00af00\">131,328</span> \u2502 dropout_10[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]  \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 batch_normalizatio\u2026 \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)       \u2502      <span style=\"color: #00af00; text-decoration-color: #00af00\">1,024</span> \u2502 dense_25[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">BatchNormalizatio\u2026</span> \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dropout_11          \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">256</span>)       \u2502          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> \u2502 batch_normalizat\u2026 \u2502\n",
+       "\u2502 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dropout</span>)           \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_26 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)    \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">64</span>)        \u2502     <span style=\"color: #00af00; text-decoration-color: #00af00\">16,448</span> \u2502 dropout_11[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]  \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_27 (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)    \u2502 (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">2</span>)         \u2502        <span style=\"color: #00af00; text-decoration-color: #00af00\">130</span> \u2502 dense_26[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]    \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u250f\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2533\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2513\n",
+       "\u2503\u001b[1m \u001b[0m\u001b[1mLayer (type)       \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1mOutput Shape     \u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1m   Param #\u001b[0m\u001b[1m \u001b[0m\u2503\u001b[1m \u001b[0m\u001b[1mConnected to     \u001b[0m\u001b[1m \u001b[0m\u2503\n",
+       "\u2521\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2547\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2529\n",
+       "\u2502 input_layer_4       \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m100\u001b[0m, \u001b[38;5;34m71\u001b[0m)   \u2502          \u001b[38;5;34m0\u001b[0m \u2502 -                 \u2502\n",
+       "\u2502 (\u001b[38;5;33mInputLayer\u001b[0m)        \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 model_feature       \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   \u2502     \u001b[38;5;34m58,496\u001b[0m \u2502 input_layer_4[\u001b[38;5;34m0\u001b[0m]\u2026 \u2502\n",
+       "\u2502 (\u001b[38;5;33mFunctional\u001b[0m)        \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 block_2 (\u001b[38;5;33mBlock\u001b[0m)     \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   \u2502    \u001b[38;5;34m148,608\u001b[0m \u2502 model_feature[\u001b[38;5;34m1\u001b[0m]\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 block_3 (\u001b[38;5;33mBlock\u001b[0m)     \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m128\u001b[0m)   \u2502    \u001b[38;5;34m148,608\u001b[0m \u2502 model_feature[\u001b[38;5;34m1\u001b[0m]\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 lambda_2 (\u001b[38;5;33mLambda\u001b[0m)   \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m1\u001b[0m)     \u2502          \u001b[38;5;34m0\u001b[0m \u2502 block_2[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]     \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 lambda_3 (\u001b[38;5;33mLambda\u001b[0m)   \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m1\u001b[0m)     \u2502          \u001b[38;5;34m0\u001b[0m \u2502 block_3[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]     \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 concatenate_1       \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m93\u001b[0m, \u001b[38;5;34m2\u001b[0m)     \u2502          \u001b[38;5;34m0\u001b[0m \u2502 lambda_2[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m],   \u2502\n",
+       "\u2502 (\u001b[38;5;33mConcatenate\u001b[0m)       \u2502                   \u2502            \u2502 lambda_3[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 global_average_poo\u2026 \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2\u001b[0m)         \u2502          \u001b[38;5;34m0\u001b[0m \u2502 concatenate_1[\u001b[38;5;34m0\u001b[0m]\u2026 \u2502\n",
+       "\u2502 (\u001b[38;5;33mGlobalAveragePool\u2026\u001b[0m \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_24 (\u001b[38;5;33mDense\u001b[0m)    \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m512\u001b[0m)       \u2502      \u001b[38;5;34m1,536\u001b[0m \u2502 global_average_p\u2026 \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 batch_normalizatio\u2026 \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m512\u001b[0m)       \u2502      \u001b[38;5;34m2,048\u001b[0m \u2502 dense_24[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    \u2502\n",
+       "\u2502 (\u001b[38;5;33mBatchNormalizatio\u2026\u001b[0m \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dropout_10          \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m512\u001b[0m)       \u2502          \u001b[38;5;34m0\u001b[0m \u2502 batch_normalizat\u2026 \u2502\n",
+       "\u2502 (\u001b[38;5;33mDropout\u001b[0m)           \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_25 (\u001b[38;5;33mDense\u001b[0m)    \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m256\u001b[0m)       \u2502    \u001b[38;5;34m131,328\u001b[0m \u2502 dropout_10[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]  \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 batch_normalizatio\u2026 \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m256\u001b[0m)       \u2502      \u001b[38;5;34m1,024\u001b[0m \u2502 dense_25[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    \u2502\n",
+       "\u2502 (\u001b[38;5;33mBatchNormalizatio\u2026\u001b[0m \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dropout_11          \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m256\u001b[0m)       \u2502          \u001b[38;5;34m0\u001b[0m \u2502 batch_normalizat\u2026 \u2502\n",
+       "\u2502 (\u001b[38;5;33mDropout\u001b[0m)           \u2502                   \u2502            \u2502                   \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_26 (\u001b[38;5;33mDense\u001b[0m)    \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m64\u001b[0m)        \u2502     \u001b[38;5;34m16,448\u001b[0m \u2502 dropout_11[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]  \u2502\n",
+       "\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u253c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n",
+       "\u2502 dense_27 (\u001b[38;5;33mDense\u001b[0m)    \u2502 (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m2\u001b[0m)         \u2502        \u001b[38;5;34m130\u001b[0m \u2502 dense_26[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]    \u2502\n",
+       "\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">508,226</span> (1.94 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m508,226\u001b[0m (1.94 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">150,978</span> (589.76 KB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m150,978\u001b[0m (589.76 KB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">357,248</span> (1.36 MB)\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m357,248\u001b[0m (1.36 MB)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Define new transformer blocks\n",
+    "new_transformer_block = Block(dim=dim, drop_path=0.2, num_heads=num_heads, topk=16, mlp_ratio=3)\n",
+    "new_transformer_block2 = Block(dim=dim, drop_path=0.2, num_heads=num_heads, topk=16, mlp_ratio=3)\n",
+    "\n",
+    "# Input for Phase 3\n",
+    "XDinput_phaz3 = Input(shape=(100, 71))\n",
+    "# Pass input through the feature extraction model\n",
+    "model_feature_output = model_feature(XDinput_phaz3)  # Output shape: (93, 192)\n",
+    "\n",
+    "# Transformer blocks processing\n",
+    "transformer_output1_phaz3 = new_transformer_block(model_feature_output)  # Output shape: (93, 192)\n",
+    "# Compute the norm along the last axis, retaining dimensions\n",
+    "transformer_output1_phaz3 = layers.Lambda(lambda x: tf.norm(x, axis=-1, keepdims=True))(transformer_output1_phaz3)  # Shape: (93, 1)\n",
+    "\n",
+    "transformer_output2_phaz3 = new_transformer_block2(model_feature_output)  # Output shape: (93, 192)\n",
+    "# Compute the norm along the last axis, retaining dimensions\n",
+    "transformer_output2_phaz3 = layers.Lambda(lambda x: tf.norm(x, axis=-1, keepdims=True))(transformer_output2_phaz3)  # Shape: (93, 1)\n",
+    "\n",
+    "# Combine the outputs of both transformer blocks\n",
+    "concatenated_phaz3 = Concatenate(axis=-1)([transformer_output1_phaz3, transformer_output2_phaz3])  # Shape: (93, 2)\n",
+    "\n",
+    "# Freeze the weights of feature extractor and transformer blocks\n",
+    "model_feature.trainable = False\n",
+    "new_transformer_block.trainable = False\n",
+    "new_transformer_block2.trainable = False\n",
+    "\n",
+    "# Apply global average pooling to reduce the dimensions to (batch_size, 2)\n",
+    "pooled_phaz3 = GlobalAveragePooling1D()(concatenated_phaz3)  # Shape: (None, 2)\n",
+    "\n",
+    "# Fully connected layers\n",
+    "FC1_phaz3 = Dense(512, activation='relu')(pooled_phaz3)\n",
+    "FC1_phaz3 = BatchNormalization()(FC1_phaz3)\n",
+    "FC2_phaz3 = Dropout(0.1)(FC1_phaz3)  # Increased dropout rate\n",
+    "FC3_phaz3 = Dense(256, activation='relu')(FC2_phaz3)\n",
+    "FC3_phaz3 = BatchNormalization()(FC3_phaz3)\n",
+    "FC4_phaz3 = Dropout(0.1)(FC3_phaz3)  # Increased dropout rate\n",
+    "FC5_phaz3 = Dense(64, activation='relu')(FC4_phaz3)\n",
+    "\n",
+    "# Final prediction layer with softmax activation\n",
+    "predictions_phaz3 = Dense(2, activation='softmax')(FC5_phaz3)\n",
+    "\n",
+    "# Define the complete model for Phase 3\n",
+    "model_phaz3 = Model(inputs=XDinput_phaz3, outputs=predictions_phaz3)\n",
+    "\n",
+    "# Print the name and trainable status of each layer\n",
+    "for layer in model_phaz3.layers:\n",
+    "    print(layer.name, layer.trainable)\n",
+    "\n",
+    "# Model summary\n",
+    "model_phaz3.summary()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "id": "jF60_7QXQ4lB"
+   },
+   "outputs": [],
+   "source": [
+    "# Metrics for binary classification tasks\n",
+    "METRICS_BINARY = [\n",
+    "    metrics.BinaryAccuracy(name='accuracy'),  # Calculates accuracy for binary classification\n",
+    "    metrics.AUC(name='auc'),  # Area Under the Curve (ROC AUC) metric\n",
+    "]\n",
+    "\n",
+    "# Metrics for categorical (multi-class) classification tasks\n",
+    "METRICS_CATEGORICAL = [\n",
+    "    metrics.CategoricalAccuracy(name='accuracy'),  # Calculates accuracy for multi-class classification\n",
+    "    metrics.Precision(name='precision'),  # Precision: TP / (TP + FP)\n",
+    "    metrics.Recall(name='recall'),  # Recall: TP / (TP + FN)\n",
+    "    metrics.AUC(name='auc'),  # Area Under the Curve (ROC AUC) metric\n",
+    "    metrics.F1Score(average='macro', name='f1_score')  # F1 Score (macro-averaged): Harmonic mean of precision and recall\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hBNS2iz6f9xP"
+   },
+   "source": [
+    "# Train and Validation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "xcS3ex1TgCRK",
+    "outputId": "7a3df7f6-88ae-459e-8e9d-fde383fd7d9c"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[19:26:23] WARNING: not removing hydrogen atom without neighbors\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of training samples: 5160\n",
+      "Number of test samples: 645\n",
+      "Epoch 1/100\n",
+      "\u001b[1m21/21\u001b[0m \u001b[32m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m\u001b[37m\u001b[0m \u001b[1m23s\u001b[0m 540ms/step - accuracy: 0.7075 - auc: 0.7846 - f1_score: 0.4252 - loss: 0.7072 - precision: 0.7075 - recall: 0.7075\n",
+      "Epoch 2/100\n",
+      "\u001b[1m21/21\u001b[0m \u001b[32m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m\u001b[37m\u001b[0m \u001b[1m12s\u001b[0m 577ms/step - accuracy: 0.6011 - auc: 0.6077 - f1_score: 0.4076 - loss: 0.6881 - precision: 0.6011 - recall: 0.6011\n",
+      "Epoch 3/100\n",
+      "\u001b[1m21/21\u001b[0m \u001b[32m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m\u001b[37m\u001b[0m \u001b[1m10s\u001b[0m 480ms/step - accuracy: 0.6849 - auc: 0.7427 - f1_score: 0.4461 - loss: 0.6743 - precision: 0.6849 - recall: 0.6849\n",
+      "Epoch 4/100\n",
+      "\u001b[1m21/21\u001b[0m \u001b[32m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m\u001b[37m\u001b[0m \u001b[1m12s\u001b[0m 563ms/step - accuracy: 0.7136 - auc: 0.7682 - f1_score: 0.4652 - loss: 0.6654 - precision: 0.7136 - recall: 0.7136\n",
+      "Epoch 5/100\n",
+      "\u001b[1m12/21\u001b[0m \u001b[32m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m\u001b[37m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[1m5s\u001b[0m 624ms/step - accuracy: 0.7234 - auc: 0.7680 - f1_score: 0.4732 - loss: 0.6852 - precision: 0.7234 - recall: 0.7234"
+     ]
+    }
+   ],
+   "source": [
+    "# Convert to numpy arrays\n",
+    "XD_np = np.array(XD)\n",
+    "labels_np = np.array(labels)\n",
+    "\n",
+    "# Remove samples that don't have labels\n",
+    "index = ~np.isnan(labels_np)\n",
+    "labels_np = labels_np[index]\n",
+    "XD_np = XD_np[index]\n",
+    "\n",
+    "# Filter the corresponding SMILES\n",
+    "filtered_smiles = smiles.iloc[index].values\n",
+    "\n",
+    "# Create a Dataset using SMILES as identifiers\n",
+    "dataset = NumpyDataset(X=XD_np, y=labels_np, ids=filtered_smiles)\n",
+    "\n",
+    "# Create a ScaffoldSplitter\n",
+    "splitter = ScaffoldSplitter()\n",
+    "\n",
+    "# Split data into training, validation, and test sets\n",
+    "train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(\n",
+    "    dataset, frac_train=0.8, frac_valid=0.1, frac_test=0.1\n",
+    ")\n",
+    "\n",
+    "# Extract training and test indices\n",
+    "train_indices = train_dataset.ids\n",
+    "test_indices = test_dataset.ids\n",
+    "smiles_to_index = {smile: idx for idx, smile in enumerate(filtered_smiles)}\n",
+    "\n",
+    "# Convert SMILES to indices\n",
+    "train_indices = np.array([smiles_to_index[smile] for smile in train_indices])\n",
+    "test_indices = np.array([smiles_to_index[smile] for smile in test_indices])\n",
+    "\n",
+    "# Split the data based on the indices\n",
+    "X_train, X_test = XD_np[train_indices], XD_np[test_indices]\n",
+    "y_train, y_test = labels_np[train_indices], labels_np[test_indices]\n",
+    "\n",
+    "print(f\"Number of training samples: {X_train.shape[0]}\")\n",
+    "print(f\"Number of test samples: {X_test.shape[0]}\")\n",
+    "\n",
+    "\n",
+    "# Convert labels to categorical format\n",
+    "y_train_cat = to_categorical(y_train, num_classes=2)\n",
+    "y_test_cat = to_categorical(y_test, num_classes=2)\n",
+    "# Compute class weights to handle class imbalance\n",
+    "class_weights_array = compute_class_weight(\n",
+    "    class_weight='balanced',\n",
+    "    classes=np.unique(y_train),\n",
+    "    y=y_train.ravel()\n",
+    ")\n",
+    "class_weight = {\n",
+    "    0: class_weights_array[0],\n",
+    "    1: class_weights_array[1]\n",
+    "}\n",
+    "\n",
+    "# === Define Optimizer for Interaction Model ===\n",
+    "opt = optimizers.Adam(learning_rate=0.0001)\n",
+    "interactionModel.compile(optimizer=opt, loss=\"categorical_crossentropy\", metrics=METRICS_CATEGORICAL)\n",
+    "\n",
+    "# Define callbacks\n",
+    "early_stopping = EarlyStopping(monitor='loss', patience=30, verbose=1, mode='min', restore_best_weights=True)\n",
+    "reduce_lr = LearningRateScheduler(lambda epoch: 1e-3 * 0.9 ** epoch)\n",
+    "\n",
+    "# === Phase 1: Train Interaction Model ===\n",
+    "interactionModel.fit(\n",
+    "    X_train, y_train_cat,\n",
+    "    batch_size=256, epochs=100, class_weight=class_weight,\n",
+    "    callbacks=[early_stopping], verbose=1\n",
+    ")\n",
+    "\n",
+    "# Evaluate Phase 1 on test data\n",
+    "test_eval_phase1 = interactionModel.evaluate(X_test, y_test_cat, verbose=1)\n",
+    "\n",
+    "# === Feature Extraction ===\n",
+    "feature_train = model_feature.predict(X_train)\n",
+    "feature_test = model_feature.predict(X_test)\n",
+    "\n",
+    "# === Phase 2: Train Model Phase 2 ===\n",
+    "opt_phaz2 = optimizers.Adam(learning_rate=0.001)\n",
+    "model_phaz2.compile(optimizer=opt_phaz2, loss=\"binary_crossentropy\", metrics=METRICS_BINARY)\n",
+    "model_phaz2.fit(\n",
+    "    feature_train, y_train,\n",
+    "    batch_size=256, epochs=100,class_weight=class_weight,\n",
+    "    callbacks=[early_stopping], verbose=1\n",
+    ")\n",
+    "\n",
+    "# === Freeze Transformer Blocks ===\n",
+    "new_transformer_block.set_weights(transformer_block1.get_weights())\n",
+    "new_transformer_block2.set_weights(transformer_block2.get_weights())  \n",
+    "\n",
+    "# === Phase 3: Train Model Phase 3 ===\n",
+    "opt_phaz3 = optimizers.Adam(learning_rate=0.0001)\n",
+    "model_phaz3.compile(optimizer=opt_phaz3, loss=\"categorical_crossentropy\", metrics=METRICS_CATEGORICAL)\n",
+    "\n",
+    "model_phaz3.fit(\n",
+    "    X_train, y_train_cat,\n",
+    "    batch_size=256, epochs=100,class_weight=class_weight,\n",
+    "    callbacks=[early_stopping], verbose=1\n",
+    ")\n",
+    "\n",
+    "# Evaluate Phase 3 on both training and testing data\n",
+    "train_eval_phase3 = model_phaz3.evaluate(X_train, y_train_cat, verbose=1)\n",
+    "test_eval_phase3 = model_phaz3.evaluate(X_test, y_test_cat, verbose=1)\n",
+    "\n",
+    "# === Function to Format Results ===\n",
+    "def format_results(phase1_result, phase3_train_result, phase3_test_result):\n",
+    "    # Define Metric Names\n",
+    "    phase1_metrics = ['loss', 'accuracy', 'precision', 'recall', 'auc', 'f1_score']\n",
+    "    phase3_metrics = ['loss', 'accuracy', 'precision', 'recall', 'auc', 'f1_score']\n",
+    "\n",
+    "    # Create DataFrames\n",
+    "    phase1_test_df = pd.DataFrame([phase1_result], columns=phase1_metrics)\n",
+    "    phase3_train_df = pd.DataFrame([phase3_train_result], columns=phase3_metrics)\n",
+    "    phase3_test_df = pd.DataFrame([test_eval_phase3], columns=phase3_metrics)\n",
+    "\n",
+    "    # Display the Results\n",
+    "    print(\"\\n=== Phase 1: Test Evaluation Results ===\")\n",
+    "    print(phase1_test_df.to_string(index=False, float_format=lambda x: f\"{x:.4f}\"))\n",
+    "\n",
+    "    print(\"\\n=== Phase 3: Train Evaluation Results ===\")\n",
+    "    print(phase3_train_df.to_string(index=False, float_format=lambda x: f\"{x:.4f}\"))\n",
+    "\n",
+    "    print(\"\\n=== Phase 3: Test Evaluation Results ===\")\n",
+    "    print(phase3_test_df.to_string(index=False, float_format=lambda x: f\"{x:.4f}\"))\n",
+    "\n",
+    "\n",
+    "# === Display Results ===\n",
+    "format_results(test_eval_phase1, train_eval_phase3, test_eval_phase3)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1f92c30c"
+   },
+   "source": [
+    "## Performance Metrics Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6a64840e"
+   },
+   "outputs": [],
+   "source": [
+    "# Visualize performance metrics\n",
+    "from sklearn.metrics import classification_report, confusion_matrix, roc_curve, auc\n",
+    "\n",
+    "# Predict probabilities and class labels for the test set\n",
+    "y_pred_prob = model_phaz3.predict(X_test)\n",
+    "y_pred = np.argmax(y_pred_prob, axis=1)\n",
+    "\n",
+    "# Confusion Matrix\n",
+    "cm = confusion_matrix(y_test, y_pred)\n",
+    "plt.figure(figsize=(5, 4))\n",
+    "sns.heatmap(cm, annot=True, fmt='d', cmap='Blues')\n",
+    "plt.xlabel('Predicted')\n",
+    "plt.ylabel('True')\n",
+    "plt.title('Confusion Matrix')\n",
+    "plt.show()\n",
+    "\n",
+    "# Classification Report\n",
+    "print(classification_report(y_test, y_pred))\n",
+    "\n",
+    "# ROC Curve\n",
+    "fpr, tpr, _ = roc_curve(y_test, y_pred_prob[:, 1])\n",
+    "roc_auc = auc(fpr, tpr)\n",
+    "plt.figure()\n",
+    "plt.plot(fpr, tpr, label=f'ROC curve (area = {roc_auc:.2f})')\n",
+    "plt.plot([0, 1], [0, 1], 'k--')\n",
+    "plt.xlabel('False Positive Rate')\n",
+    "plt.ylabel('True Positive Rate')\n",
+    "plt.title('Receiver Operating Characteristic')\n",
+    "plt.legend(loc='lower right')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
- add confusion matrix, classification report, and ROC curve visualization at the end of `Tox21_NR_PPAR_gamma_Scaffold splitting.ipynb`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850eeac98ac833394d10bbe70504179