### PR TITLE
Add demo notebook for training functions

### DIFF
--- a/src/demo_run.ipynb
+++ b/src/demo_run.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deep-CBN Demo\n",
+    "This notebook demonstrates using the helper functions from `train_deep_cbn_fnx.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from train_deep_cbn_fnx import train_deep_cbn, calculate_roc_auc, plot_confusion_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "dataset_path = '../Data/tox21.csv'\n",
+    "target_col = 'NR-PPAR-gamma'\n",
+    "smiles_col = 'smiles'\n",
+    "\n",
+    "# Train a model with minimal epochs for demonstration\n",
+    "model, train_eval, test_eval, X_test, y_test_cat = train_deep_cbn(dataset_path, target_col, smiles_col, n_epochs=1)\n",
+    "\n",
+    "# Evaluate\n",
+    "roc_auc = calculate_roc_auc(model, X_test, y_test_cat)\n",
+    "print(f'ROC-AUC: {roc_auc:.4f}')\n",
+    "plot_confusion_matrix(model, X_test, y_test_cat, class_names=['Negative','Positive'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create `demo_run.ipynb` to show how to import `train_deep_cbn_fnx` helpers
- run `train_deep_cbn`, `calculate_roc_auc` and `plot_confusion_matrix` on Tox21 test data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853348c99248333a7d6ec8669abefff